### PR TITLE
CKV_K8S_92 api server audit log max age

### DIFF
--- a/checkov/kubernetes/checks/ApiServerAuditLogMaxAge.py
+++ b/checkov/kubernetes/checks/ApiServerAuditLogMaxAge.py
@@ -1,0 +1,29 @@
+from checkov.common.models.enums import CheckCategories, CheckResult
+from checkov.kubernetes.base_spec_check import BaseK8Check
+
+class ApiServerAuditLogMaxAge(BaseK8Check):
+    def __init__(self):
+        # CIS-1.6 1.2.23
+        id = "CKV_K8S_92"
+        name = "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate"
+        categories = [CheckCategories.KUBERNETES]
+        supported_entities = ['containers']
+        super().__init__(name=name, id=id, categories=categories, supported_entities=supported_entities)
+
+    def get_resource_id(self, conf):
+        return f'{conf["parent"]} - {conf["name"]}'
+
+    def scan_spec_conf(self, conf):
+        if "command" in conf:
+            if "kube-apiserver" in conf["command"]:
+                hasAuditLogMaxAge = False
+                for command in conf["command"]:
+                    if command.startswith("--audit-log-maxage"):
+                        value = command.split("=")[1]
+                        hasAuditLog = int(value) >= 30
+                        break
+                return CheckResult.PASSED if hasAuditLogMaxAge else CheckResult.FAILED
+           
+        return CheckResult.PASSED
+
+check = ApiServerAuditLogMaxAge()

--- a/tests/kubernetes/checks/example_ApiServerAuditLogMaxAge/ApiServer-FAILED.yaml
+++ b/tests/kubernetes/checks/example_ApiServerAuditLogMaxAge/ApiServer-FAILED.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    component: kube-apiserver
+    tier: control-plane
+  name: kube-apiserver
+  namespace: kube-system
+spec:
+  containers:
+  - command:
+    - kube-apiserver
+    - --audit-log-maxage=10
+    image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+    livenessProbe:
+      failureThreshold: 8
+      httpGet:
+        host: 127.0.0.1
+        path: /healthz
+        port: 6443
+        scheme: HTTPS
+      initialDelaySeconds: 15
+      timeoutSeconds: 15
+    name: kube-apiserver
+    resources:
+      requests:
+        cpu: 250m
+    volumeMounts:
+    - mountPath: /etc/kubernetes/
+      name: k8s
+      readOnly: true
+    - mountPath: /etc/ssl/certs
+      name: certs
+    - mountPath: /etc/pki
+      name: pki
+  hostNetwork: true
+  volumes:
+  - hostPath:
+      path: /etc/kubernetes
+    name: k8s
+  - hostPath:
+      path: /etc/ssl/certs
+    name: certs
+  - hostPath:
+      path: /etc/pki
+    name: pki

--- a/tests/kubernetes/checks/example_ApiServerAuditLogMaxAge/ApiServer-PASSED.yaml
+++ b/tests/kubernetes/checks/example_ApiServerAuditLogMaxAge/ApiServer-PASSED.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    component: kube-apiserver
+    tier: control-plane
+  name: kube-apiserver
+  namespace: kube-system
+spec:
+  containers:
+  - command:
+    - kube-apiserver
+    - --audit-log-maxage=40
+    image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+    livenessProbe:
+      failureThreshold: 8
+      httpGet:
+        host: 127.0.0.1
+        path: /healthz
+        port: 6443
+        scheme: HTTPS
+      initialDelaySeconds: 15
+      timeoutSeconds: 15
+    name: kube-apiserver
+    resources:
+      requests:
+        cpu: 250m
+    volumeMounts:
+    - mountPath: /etc/kubernetes/
+      name: k8s
+      readOnly: true
+    - mountPath: /etc/ssl/certs
+      name: certs
+    - mountPath: /etc/pki
+      name: pki
+  hostNetwork: true
+  volumes:
+  - hostPath:
+      path: /etc/kubernetes
+    name: k8s
+  - hostPath:
+      path: /etc/ssl/certs
+    name: certs
+  - hostPath:
+      path: /etc/pki
+    name: pki

--- a/tests/kubernetes/checks/test_ApiServerAuditLogMaxAge.py
+++ b/tests/kubernetes/checks/test_ApiServerAuditLogMaxAge.py
@@ -1,0 +1,26 @@
+import os
+import unittest
+
+from checkov.kubernetes.checks.ApiServerAuditLogMaxAge import check
+from checkov.kubernetes.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+
+class TestApiServerAuditLogMaxAge(unittest.TestCase):
+
+    def test_summary(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_ApiServerAuditLogMaxAge"
+        report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        self.assertEqual(summary['passed'], 1)
+        self.assertEqual(summary['failed'], 1)
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Ensure that the --audit-log-maxage argument is set to 30 or as appropriate
Id = CKV_K8S_92
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
