### PR TITLE
Implement CKV_AWS_106

### DIFF
--- a/checkov/terraform/checks/resource/aws/KubernetesSecretsEncryptedUsingCMK.py
+++ b/checkov/terraform/checks/resource/aws/KubernetesSecretsEncryptedUsingCMK.py
@@ -1,0 +1,27 @@
+from checkov.arm.base_resource_check import BaseResourceCheck
+from checkov.common.models.enums import CheckCategories, CheckResult
+
+
+class KubernetesSecretsEncryptedUsingCMK(BaseResourceCheck):
+    def __init__(self):
+        name = "Ensure Kubernetes Secrets are encrypted using Customer Master Keys (CMKs) managed in AWS KMS"
+        id = "CKV_AWS_106"
+        supported_resources = ['aws_eks_cluster']
+        categories = [CheckCategories.KUBERNETES]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf):
+        if 'encryption_config' not in conf.keys():
+            return CheckResult.FAILED
+        else:
+            encryption_config = conf.get('encryption_config')[0]
+            if 'resources' in encryption_config and 'provider' in encryption_config:
+                resources = encryption_config.get('resources')[0]
+                provider = encryption_config.get('provider')[0]
+                if type(resources) is list:
+                    if 'secrets' in resources and 'key_arn' in provider:
+                        return CheckResult.PASSED
+        return CheckResult.FAILED
+
+
+check = KubernetesSecretsEncryptedUsingCMK()

--- a/tests/terraform/checks/resource/aws/test_KubernetesSecretsEncryptedUsingCMK.py
+++ b/tests/terraform/checks/resource/aws/test_KubernetesSecretsEncryptedUsingCMK.py
@@ -1,0 +1,71 @@
+import unittest
+
+import hcl2
+
+from checkov.terraform.checks.resource.aws.KubernetesSecretsEncryptedUsingCMK import check
+from checkov.common.models.enums import CheckResult
+
+
+class TestKubernetesSecretsEncryptedUsingCMK(unittest.TestCase):
+
+    def test_failure1(self):
+        hcl_res = hcl2.loads("""
+            resource "aws_eks_cluster" "test" {
+              name     = "example"
+              role_arn = aws_iam_role.example.arn
+            
+              vpc_config {
+                    subnet_ids = [aws_subnet.example1.id, aws_subnet.example2.id]
+                }
+              }
+        """)
+        resource_conf = hcl_res['resource'][0]['aws_eks_cluster']['test']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_failure2(self):
+        hcl_res = hcl2.loads("""
+            resource "aws_eks_cluster" "test" {
+              name     = "example"
+              role_arn = aws_iam_role.example.arn
+
+              vpc_config {
+                    subnet_ids = [aws_subnet.example1.id, aws_subnet.example2.id]
+                }
+             encryption_config {
+                            resources = ["test"]
+                            provider {
+                                key_arn = "test"
+                             }
+                      }   
+              }
+        """)
+        resource_conf = hcl_res['resource'][0]['aws_eks_cluster']['test']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_success(self):
+        hcl_res = hcl2.loads("""
+                    resource "aws_eks_cluster" "test" {
+                      name     = "example"
+                      role_arn = aws_iam_role.example.arn
+
+                      vpc_config {
+                        subnet_ids = [aws_subnet.example1.id, aws_subnet.example2.id]
+                      }
+                      
+                      encryption_config {
+                            resources = ["secrets"]
+                            provider {
+                                key_arn = "test"
+                             }
+                      }
+                    }
+                """)
+        resource_conf = hcl_res['resource'][0]['aws_eks_cluster']['test']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
CKV_AWS_106
Ensure Kubernetes Secrets are encrypted using Customer Master Keys (CMKs) managed in AWS KMS 
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_cluster#provider