### PR TITLE
CKV_K8S_94  api server audit log max size

### DIFF
--- a/checkov/kubernetes/checks/ApiServerAuditLogMaxSize.py
+++ b/checkov/kubernetes/checks/ApiServerAuditLogMaxSize.py
@@ -1,0 +1,29 @@
+from checkov.common.models.enums import CheckCategories, CheckResult
+from checkov.kubernetes.base_spec_check import BaseK8Check
+
+class ApiServerAuditLogMaxSize(BaseK8Check):
+    def __init__(self):
+        # CIS-1.6 1.2.25
+        id = "CKV_K8S_94"
+        name = "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate"
+        categories = [CheckCategories.KUBERNETES]
+        supported_entities = ['containers']
+        super().__init__(name=name, id=id, categories=categories, supported_entities=supported_entities)
+
+    def get_resource_id(self, conf):
+        return f'{conf["parent"]} - {conf["name"]}'
+
+    def scan_spec_conf(self, conf):
+        if "command" in conf:
+            if "kube-apiserver" in conf["command"]:
+                hasAuditLogMaxSize = False
+                for command in conf["command"]:
+                    if command.startswith("--audit-log-maxsize"):
+                        value = command.split("=")[1]
+                        hasAuditLogMaxSize = int(value) >= 100
+                        break
+                return CheckResult.PASSED if hasAuditLogMaxSize else CheckResult.FAILED
+           
+        return CheckResult.PASSED
+
+check = ApiServerAuditLogMaxSize()

--- a/tests/kubernetes/checks/example_ApiServerAuditLogMaxSize/ApiServer-FAILED-2.yaml
+++ b/tests/kubernetes/checks/example_ApiServerAuditLogMaxSize/ApiServer-FAILED-2.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    component: kube-apiserver
+    tier: control-plane
+  name: kube-apiserver
+  namespace: kube-system
+spec:
+  containers:
+  - command:
+    - kube-apiserver
+    - --audit-log-maxsize=10
+    image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+    livenessProbe:
+      failureThreshold: 8
+      httpGet:
+        host: 127.0.0.1
+        path: /healthz
+        port: 6443
+        scheme: HTTPS
+      initialDelaySeconds: 15
+      timeoutSeconds: 15
+    name: kube-apiserver
+    resources:
+      requests:
+        cpu: 250m
+    volumeMounts:
+    - mountPath: /etc/kubernetes/
+      name: k8s
+      readOnly: true
+    - mountPath: /etc/ssl/certs
+      name: certs
+    - mountPath: /etc/pki
+      name: pki
+  hostNetwork: true
+  volumes:
+  - hostPath:
+      path: /etc/kubernetes
+    name: k8s
+  - hostPath:
+      path: /etc/ssl/certs
+    name: certs
+  - hostPath:
+      path: /etc/pki
+    name: pki

--- a/tests/kubernetes/checks/example_ApiServerAuditLogMaxSize/ApiServer-FAILED.yaml
+++ b/tests/kubernetes/checks/example_ApiServerAuditLogMaxSize/ApiServer-FAILED.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    component: kube-apiserver
+    tier: control-plane
+  name: kube-apiserver
+  namespace: kube-system
+spec:
+  containers:
+  - command:
+    - kube-apiserver
+    image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+    livenessProbe:
+      failureThreshold: 8
+      httpGet:
+        host: 127.0.0.1
+        path: /healthz
+        port: 6443
+        scheme: HTTPS
+      initialDelaySeconds: 15
+      timeoutSeconds: 15
+    name: kube-apiserver
+    resources:
+      requests:
+        cpu: 250m
+    volumeMounts:
+    - mountPath: /etc/kubernetes/
+      name: k8s
+      readOnly: true
+    - mountPath: /etc/ssl/certs
+      name: certs
+    - mountPath: /etc/pki
+      name: pki
+  hostNetwork: true
+  volumes:
+  - hostPath:
+      path: /etc/kubernetes
+    name: k8s
+  - hostPath:
+      path: /etc/ssl/certs
+    name: certs
+  - hostPath:
+      path: /etc/pki
+    name: pki

--- a/tests/kubernetes/checks/example_ApiServerAuditLogMaxSize/ApiServer-PASSED.yaml
+++ b/tests/kubernetes/checks/example_ApiServerAuditLogMaxSize/ApiServer-PASSED.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    component: kube-apiserver
+    tier: control-plane
+  name: kube-apiserver
+  namespace: kube-system
+spec:
+  containers:
+  - command:
+    - kube-apiserver
+    - --audit-log-maxsize=150
+    image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+    livenessProbe:
+      failureThreshold: 8
+      httpGet:
+        host: 127.0.0.1
+        path: /healthz
+        port: 6443
+        scheme: HTTPS
+      initialDelaySeconds: 15
+      timeoutSeconds: 15
+    name: kube-apiserver
+    resources:
+      requests:
+        cpu: 250m
+    volumeMounts:
+    - mountPath: /etc/kubernetes/
+      name: k8s
+      readOnly: true
+    - mountPath: /etc/ssl/certs
+      name: certs
+    - mountPath: /etc/pki
+      name: pki
+  hostNetwork: true
+  volumes:
+  - hostPath:
+      path: /etc/kubernetes
+    name: k8s
+  - hostPath:
+      path: /etc/ssl/certs
+    name: certs
+  - hostPath:
+      path: /etc/pki
+    name: pki

--- a/tests/kubernetes/checks/test_ApiServerAuditLogMaxSize.py
+++ b/tests/kubernetes/checks/test_ApiServerAuditLogMaxSize.py
@@ -6,7 +6,7 @@ from checkov.kubernetes.runner import Runner
 from checkov.runner_filter import RunnerFilter
 
 
-class TestApiServerProfiling(unittest.TestCase):
+class TestApiServerAuditLogMaxSize(unittest.TestCase):
 
     def test_summary(self):
         runner = Runner()

--- a/tests/kubernetes/checks/test_ApiServerAuditLogMaxSize.py
+++ b/tests/kubernetes/checks/test_ApiServerAuditLogMaxSize.py
@@ -1,0 +1,26 @@
+import os
+import unittest
+
+from checkov.kubernetes.checks.ApiServerAuditLogMaxSize import check
+from checkov.kubernetes.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+
+class TestApiServerProfiling(unittest.TestCase):
+
+    def test_summary(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_ApiServerAuditLogMaxSize"
+        report = runner.run(root_folder=test_files_dir,runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        self.assertEqual(summary['passed'], 1)
+        self.assertEqual(summary['failed'], 2)
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate
Id = CKV_K8S_94

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
