### PR TITLE
Fix(K8S checks): Add None check to prevent errors

### DIFF
--- a/checkov/kubernetes/checks/ApiServerAuditLog.py
+++ b/checkov/kubernetes/checks/ApiServerAuditLog.py
@@ -14,7 +14,7 @@ class ApiServerAuditLog(BaseK8Check):
         return f'{conf["parent"]} - {conf["name"]}'
 
     def scan_spec_conf(self, conf):
-        if "command" in conf:
+        if "command" in conf and conf["command"] is not None:
             if "kube-apiserver" in conf["command"]:
                 hasAuditLog = False
                 for command in conf["command"]:

--- a/checkov/kubernetes/checks/ApiServerAuditLogMaxAge.py
+++ b/checkov/kubernetes/checks/ApiServerAuditLogMaxAge.py
@@ -14,7 +14,7 @@ class ApiServerAuditLogMaxAge(BaseK8Check):
         return f'{conf["parent"]} - {conf["name"]}'
 
     def scan_spec_conf(self, conf):
-        if "command" in conf:
+        if "command" in conf and conf["command"] is not None:
             if "kube-apiserver" in conf["command"]:
                 hasAuditLogMaxAge = False
                 for command in conf["command"]:

--- a/checkov/kubernetes/checks/ApiServerAuditLogMaxBackup.py
+++ b/checkov/kubernetes/checks/ApiServerAuditLogMaxBackup.py
@@ -14,7 +14,7 @@ class ApiServerAuditLogMaxBackup(BaseK8Check):
         return f'{conf["parent"]} - {conf["name"]}'
 
     def scan_spec_conf(self, conf):
-        if "command" in conf:
+        if "command" in conf and conf["command"] is not None:
             if "kube-apiserver" in conf["command"]:
                 hasAuditLogMaxBackup = False
                 for command in conf["command"]:

--- a/checkov/kubernetes/checks/ApiServerAuditLogMaxSize.py
+++ b/checkov/kubernetes/checks/ApiServerAuditLogMaxSize.py
@@ -14,7 +14,7 @@ class ApiServerAuditLogMaxSize(BaseK8Check):
         return f'{conf["parent"]} - {conf["name"]}'
 
     def scan_spec_conf(self, conf):
-        if "command" in conf:
+        if "command" in conf and conf["command"] is not None:
             if "kube-apiserver" in conf["command"]:
                 hasAuditLogMaxSize = False
                 for command in conf["command"]:

--- a/checkov/kubernetes/checks/ApiServerProfiling.py
+++ b/checkov/kubernetes/checks/ApiServerProfiling.py
@@ -14,7 +14,7 @@ class ApiServerProfiling(BaseK8Check):
         return f'{conf["parent"]} - {conf["name"]}'
 
     def scan_spec_conf(self, conf):
-        if "command" in conf:
+        if "command" in conf and conf["command"] is not None:
             if "kube-apiserver" in conf["command"]:
                 if "--profiling=true" in conf["command"] or "--profiling=false" not in conf["command"]:
                     return CheckResult.FAILED

--- a/checkov/kubernetes/checks/ApiServerServiceAccountLookup.py
+++ b/checkov/kubernetes/checks/ApiServerServiceAccountLookup.py
@@ -14,7 +14,7 @@ class ApiServerServiceAccountLookup(BaseK8Check):
         return f'{conf["parent"]} - {conf["name"]}'
 
     def scan_spec_conf(self, conf):
-        if "command" in conf:
+        if "command" in conf and conf["command"] is not None:
             if "kube-apiserver" in conf["command"]:
                 if "--service-account-lookup=false" in conf["command"] or "--service-account-lookup=true" not in conf["command"]:
                     return CheckResult.FAILED


### PR DESCRIPTION
Make sure `command` is not `None` to prevent exceptions
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
