### PR TITLE
CKV_K8S_99 k8s api server etcd key and cert

### DIFF
--- a/checkov/kubernetes/checks/ApiServerEtcdCertAndKey.py
+++ b/checkov/kubernetes/checks/ApiServerEtcdCertAndKey.py
@@ -19,10 +19,10 @@ class ApiServerEtcdCertAndKey(BaseK8Check):
             if "kube-apiserver" in conf["command"]:
                 hasCertCommand = False
                 hasKeyCommand = False
-                for command in conf["command"]):
-                    if command.startsWith("--etcd-certfile"):
+                for command in conf["command"]:
+                    if command.startswith("--etcd-certfile"):
                         hasCertCommand = True
-                    elif command.startsWith("--etcd-keyfile"):
+                    elif command.startswith("--etcd-keyfile"):
                         hasKeyCommand = True
                 return CheckResult.PASSED if hasCertCommand and hasKeyCommand else CheckResult.FAILED
 

--- a/checkov/kubernetes/checks/ApiServerEtcdCertAndKey.py
+++ b/checkov/kubernetes/checks/ApiServerEtcdCertAndKey.py
@@ -15,7 +15,7 @@ class ApiServerEtcdCertAndKey(BaseK8Check):
         return f'{conf["parent"]} - {conf["name"]}'
 
     def scan_spec_conf(self, conf):
-        if "command" in conf and conf["command"] is not None:
+        if conf.get("command") is not None:
             if "kube-apiserver" in conf["command"]:
                 hasCertCommand = False
                 hasKeyCommand = False

--- a/checkov/kubernetes/checks/ApiServerEtcdCertAndKey.py
+++ b/checkov/kubernetes/checks/ApiServerEtcdCertAndKey.py
@@ -1,0 +1,32 @@
+from checkov.common.models.enums import CheckCategories, CheckResult
+from checkov.kubernetes.base_spec_check import BaseK8Check
+
+
+class ApiServerEtcdCertAndKey(BaseK8Check):
+    def __init__(self):
+        # CIS-1.6 1.2.29
+        id = "CKV_K8S_99"
+        name = "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate"
+        categories = [CheckCategories.KUBERNETES]
+        supported_entities = ['containers']
+        super().__init__(name=name, id=id, categories=categories, supported_entities=supported_entities)
+
+    def get_resource_id(self, conf):
+        return f'{conf["parent"]} - {conf["name"]}'
+
+    def scan_spec_conf(self, conf):
+        if "command" in conf and conf["command"] is not None:
+            if "kube-apiserver" in conf["command"]:
+                hasCertCommand = False
+                hasKeyCommand = False
+                for command in conf["command"]):
+                    if command.startsWith("--etcd-certfile"):
+                        hasCertCommand = True
+                    elif command.startsWith("--etcd-keyfile"):
+                        hasKeyCommand = True
+                return CheckResult.PASSED if hasCertCommand and hasKeyCommand else CheckResult.FAILED
+
+        return CheckResult.PASSED
+
+
+check = ApiServerEtcdCertAndKey()

--- a/tests/kubernetes/checks/example_ApiServerEtcdCertAndKey/ApiServer-FAILED-2.yaml
+++ b/tests/kubernetes/checks/example_ApiServerEtcdCertAndKey/ApiServer-FAILED-2.yaml
@@ -22,7 +22,7 @@ spec:
         scheme: HTTPS
       initialDelaySeconds: 15
       timeoutSeconds: 15
-    name: kube-apiserver
+    name: kube-apiserver-should-fail
     resources:
       requests:
         cpu: 250m

--- a/tests/kubernetes/checks/example_ApiServerEtcdCertAndKey/ApiServer-FAILED-2.yaml
+++ b/tests/kubernetes/checks/example_ApiServerEtcdCertAndKey/ApiServer-FAILED-2.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    component: kube-apiserver
+    tier: control-plane
+  name: kube-apiserver
+  namespace: kube-system
+spec:
+  containers:
+  - command:
+    - kube-apiserver
+    - --etcd-certfile=/path/to/cert
+    image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+    livenessProbe:
+      failureThreshold: 8
+      httpGet:
+        host: 127.0.0.1
+        path: /healthz
+        port: 6443
+        scheme: HTTPS
+      initialDelaySeconds: 15
+      timeoutSeconds: 15
+    name: kube-apiserver
+    resources:
+      requests:
+        cpu: 250m
+    volumeMounts:
+    - mountPath: /etc/kubernetes/
+      name: k8s
+      readOnly: true
+    - mountPath: /etc/ssl/certs
+      name: certs
+    - mountPath: /etc/pki
+      name: pki
+  hostNetwork: true
+  volumes:
+  - hostPath:
+      path: /etc/kubernetes
+    name: k8s
+  - hostPath:
+      path: /etc/ssl/certs
+    name: certs
+  - hostPath:
+      path: /etc/pki
+    name: pki

--- a/tests/kubernetes/checks/example_ApiServerEtcdCertAndKey/ApiServer-FAILED.yaml
+++ b/tests/kubernetes/checks/example_ApiServerEtcdCertAndKey/ApiServer-FAILED.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    component: kube-apiserver
+    tier: control-plane
+  name: kube-apiserver
+  namespace: kube-system
+spec:
+  containers:
+  - command:
+    - kube-apiserver
+    image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+    livenessProbe:
+      failureThreshold: 8
+      httpGet:
+        host: 127.0.0.1
+        path: /healthz
+        port: 6443
+        scheme: HTTPS
+      initialDelaySeconds: 15
+      timeoutSeconds: 15
+    name: kube-apiserver
+    resources:
+      requests:
+        cpu: 250m
+    volumeMounts:
+    - mountPath: /etc/kubernetes/
+      name: k8s
+      readOnly: true
+    - mountPath: /etc/ssl/certs
+      name: certs
+    - mountPath: /etc/pki
+      name: pki
+  hostNetwork: true
+  volumes:
+  - hostPath:
+      path: /etc/kubernetes
+    name: k8s
+  - hostPath:
+      path: /etc/ssl/certs
+    name: certs
+  - hostPath:
+      path: /etc/pki
+    name: pki

--- a/tests/kubernetes/checks/example_ApiServerEtcdCertAndKey/ApiServer-FAILED.yaml
+++ b/tests/kubernetes/checks/example_ApiServerEtcdCertAndKey/ApiServer-FAILED.yaml
@@ -21,7 +21,7 @@ spec:
         scheme: HTTPS
       initialDelaySeconds: 15
       timeoutSeconds: 15
-    name: kube-apiserver
+    name: kube-apiserver-should-fail
     resources:
       requests:
         cpu: 250m

--- a/tests/kubernetes/checks/example_ApiServerEtcdCertAndKey/ApiServer-PASSED.yaml
+++ b/tests/kubernetes/checks/example_ApiServerEtcdCertAndKey/ApiServer-PASSED.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    component: kube-apiserver
+    tier: control-plane
+  name: kube-apiserver
+  namespace: kube-system
+spec:
+  containers:
+  - command:
+    - kube-apiserver
+    - --etcd-certfile=/path/to/cert
+    - --etcd-keyfile=/path/to/key
+    image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+    livenessProbe:
+      failureThreshold: 8
+      httpGet:
+        host: 127.0.0.1
+        path: /healthz
+        port: 6443
+        scheme: HTTPS
+      initialDelaySeconds: 15
+      timeoutSeconds: 15
+    name: kube-apiserver
+    resources:
+      requests:
+        cpu: 250m
+    volumeMounts:
+    - mountPath: /etc/kubernetes/
+      name: k8s
+      readOnly: true
+    - mountPath: /etc/ssl/certs
+      name: certs
+    - mountPath: /etc/pki
+      name: pki
+  hostNetwork: true
+  volumes:
+  - hostPath:
+      path: /etc/kubernetes
+    name: k8s
+  - hostPath:
+      path: /etc/ssl/certs
+    name: certs
+  - hostPath:
+      path: /etc/pki
+    name: pki

--- a/tests/kubernetes/checks/example_ApiServerEtcdCertAndKey/ApiServer-PASSED.yaml
+++ b/tests/kubernetes/checks/example_ApiServerEtcdCertAndKey/ApiServer-PASSED.yaml
@@ -23,7 +23,7 @@ spec:
         scheme: HTTPS
       initialDelaySeconds: 15
       timeoutSeconds: 15
-    name: kube-apiserver
+    name: kube-apiserver-should-pass
     resources:
       requests:
         cpu: 250m

--- a/tests/kubernetes/checks/test_ApiServerEtcdCertAndKey.py
+++ b/tests/kubernetes/checks/test_ApiServerEtcdCertAndKey.py
@@ -21,6 +21,11 @@ class TestApiServerEtcdCertAndKey(unittest.TestCase):
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)
 
+        for failed in report.failed_checks:
+            self.assertTrue("should-fail" in failed.resource)
+        for passed in report.passed_checks:
+            self.assertTrue("should-pass" in passed.resource)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/kubernetes/checks/test_ApiServerEtcdCertAndKey.py
+++ b/tests/kubernetes/checks/test_ApiServerEtcdCertAndKey.py
@@ -1,0 +1,26 @@
+import os
+import unittest
+
+from checkov.kubernetes.checks.ApiServerEtcdCertAndKey import check
+from checkov.kubernetes.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+
+class TestApiServerEtcdCertAndKey(unittest.TestCase):
+
+    def test_summary(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/example_ApiServerEtcdCertAndKey"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        self.assertEqual(summary['passed'], 1)
+        self.assertEqual(summary['failed'], 2)
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate
Id = CKV_K8S_99

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
