### PR TITLE
metadata and release channel checks

### DIFF
--- a/checkov/terraform/checks/resource/gcp/GKEMetadataServerisEnabled.py
+++ b/checkov/terraform/checks/resource/gcp/GKEMetadataServerisEnabled.py
@@ -1,0 +1,20 @@
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from checkov.common.models.enums import CheckCategories
+
+
+class GKEMetadataServerisEnabled(BaseResourceValueCheck):
+    def __init__(self):
+        name = "Ensure the GKE Metadata Server is Enabled"
+        id = "CKV_GCP_61"
+        supported_resources = ['google_container_cluster','google_container_node_pool']
+        categories = [CheckCategories.KUBERNETES]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self):
+        return 'node_config/[0]/workload_metadata_config/[0]/node_metadata'
+
+    def get_expected_values(self):
+        return "GKE_METADATA_SERVER"
+
+
+check = GKEMetadataServerisEnabled()

--- a/checkov/terraform/checks/resource/gcp/GKEMetadataServerisEnabled.py
+++ b/checkov/terraform/checks/resource/gcp/GKEMetadataServerisEnabled.py
@@ -5,7 +5,7 @@ from checkov.common.models.enums import CheckCategories
 class GKEMetadataServerisEnabled(BaseResourceValueCheck):
     def __init__(self):
         name = "Ensure the GKE Metadata Server is Enabled"
-        id = "CKV_GCP_61"
+        id = "CKV_GCP_69"
         supported_resources = ['google_container_cluster','google_container_node_pool']
         categories = [CheckCategories.KUBERNETES]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)

--- a/checkov/terraform/checks/resource/gcp/GKEReleaseChannel.py
+++ b/checkov/terraform/checks/resource/gcp/GKEReleaseChannel.py
@@ -1,0 +1,21 @@
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from checkov.common.models.enums import CheckCategories
+from checkov.common.models.consts import ANY_VALUE
+
+
+class ReleaseChannel(BaseResourceValueCheck):
+    def __init__(self):
+        name = "Ensure the GKE Release Channel is set"
+        id = "CKV_GCP_64"
+        supported_resources = ['google_container_cluster']
+        categories = [CheckCategories.KUBERNETES]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self):
+        return 'release_channel/[0]/channel'
+
+    def get_expected_values(self):
+        return [ANY_VALUE]
+
+
+check = ReleaseChannel()

--- a/checkov/terraform/checks/resource/gcp/GKEReleaseChannel.py
+++ b/checkov/terraform/checks/resource/gcp/GKEReleaseChannel.py
@@ -6,7 +6,7 @@ from checkov.common.models.consts import ANY_VALUE
 class ReleaseChannel(BaseResourceValueCheck):
     def __init__(self):
         name = "Ensure the GKE Release Channel is set"
-        id = "CKV_GCP_64"
+        id = "CKV_GCP_70"
         supported_resources = ['google_container_cluster']
         categories = [CheckCategories.KUBERNETES]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)

--- a/tests/terraform/checks/resource/gcp/test_GKEMetadataServerisEnabled.py
+++ b/tests/terraform/checks/resource/gcp/test_GKEMetadataServerisEnabled.py
@@ -1,0 +1,41 @@
+import unittest
+import os
+
+from checkov.terraform.checks.resource.gcp.GKEMetadataServerisEnabled import check
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.runner import Runner
+
+
+class TestGKEMetadataServerisEnabled(unittest.TestCase):
+
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/test_GKEMetadataServerisEnabled"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            'google_container_cluster.success',
+            'google_container_node_pool.success'
+        }
+        failing_resources = {
+            'google_container_cluster.fail',
+            'google_container_node_pool.fail'
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary['passed'], 2)
+        self.assertEqual(summary['failed'], 2)
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/terraform/checks/resource/gcp/test_GKEMetadataServerisEnabled/main.tf
+++ b/tests/terraform/checks/resource/gcp/test_GKEMetadataServerisEnabled/main.tf
@@ -1,0 +1,89 @@
+
+resource "google_container_cluster" "fail" {
+  name               = var.name
+  location           = var.location
+  initial_node_count = 1
+  project            = data.google_project.project.name
+
+  network    = var.network
+  subnetwork = var.subnetwork
+
+  ip_allocation_policy {
+    cluster_ipv4_cidr_block       = var.ip_allocation_policy["cluster_ipv4_cidr_block"]
+    cluster_secondary_range_name  = var.ip_allocation_policy["cluster_secondary_range_name"]
+    services_ipv4_cidr_block      = var.ip_allocation_policy["services_ipv4_cidr_block"]
+    services_secondary_range_name = var.ip_allocation_policy["services_secondary_range_name"]
+  }
+}
+
+resource "google_container_node_pool" "fail" {
+  project  = data.google_project.project.name
+  name     = var.node_pool["name"]
+  location = var.location
+  cluster  = google_container_cluster.cluster.name
+
+  node_count        = var.node_pool["node_count"]
+  max_pods_per_node = var.node_pool["max_pods_per_node"]
+
+  node_config {
+    machine_type = var.node_pool["machine_type"]
+    disk_size_gb = var.node_pool["disk_size_gb"]
+    disk_type    = var.node_pool["disk_type"]
+
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/compute",
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+    ]
+  }
+}
+
+resource "google_container_cluster" "success" {
+  name               = var.name
+  location           = var.location
+  initial_node_count = 1
+  project            = data.google_project.project.name
+
+  network    = var.network
+  subnetwork = var.subnetwork
+
+  ip_allocation_policy {
+    cluster_ipv4_cidr_block       = var.ip_allocation_policy["cluster_ipv4_cidr_block"]
+    cluster_secondary_range_name  = var.ip_allocation_policy["cluster_secondary_range_name"]
+    services_ipv4_cidr_block      = var.ip_allocation_policy["services_ipv4_cidr_block"]
+    services_secondary_range_name = var.ip_allocation_policy["services_secondary_range_name"]
+  }
+
+  node_config {
+    workload_metadata_config {
+      node_metadata = "GKE_METADATA_SERVER"
+    }
+  }
+}
+
+resource "google_container_node_pool" "success" {
+  project  = data.google_project.project.name
+  name     = var.node_pool["name"]
+  location = var.location
+  cluster  = google_container_cluster.cluster.name
+
+  node_count        = var.node_pool["node_count"]
+  max_pods_per_node = var.node_pool["max_pods_per_node"]
+
+  node_config {
+    machine_type = var.node_pool["machine_type"]
+    disk_size_gb = var.node_pool["disk_size_gb"]
+    disk_type    = var.node_pool["disk_type"]
+
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/compute",
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+    ]
+    workload_metadata_config {
+      node_metadata = "GKE_METADATA_SERVER"
+    }
+  }
+}

--- a/tests/terraform/checks/resource/gcp/test_GKEReleaseChannel.py
+++ b/tests/terraform/checks/resource/gcp/test_GKEReleaseChannel.py
@@ -1,0 +1,39 @@
+import unittest
+import os
+
+from checkov.terraform.checks.resource.gcp.GKEReleaseChannel import check
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.runner import Runner
+
+
+class TestGKEReleaseChannel(unittest.TestCase):
+
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/test_GKEReleaseChannel"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            'google_container_cluster.success'
+        }
+        failing_resources = {
+            'google_container_cluster.fail'
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary['passed'], 1)
+        self.assertEqual(summary['failed'], 1)
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/terraform/checks/resource/gcp/test_GKEReleaseChannel/main.tf
+++ b/tests/terraform/checks/resource/gcp/test_GKEReleaseChannel/main.tf
@@ -1,0 +1,46 @@
+
+resource "google_container_cluster" "fail" {
+  name               = var.name
+  location           = var.location
+  initial_node_count = 1
+  project            = data.google_project.project.name
+
+  network    = var.network
+  subnetwork = var.subnetwork
+
+  ip_allocation_policy {
+    cluster_ipv4_cidr_block       = var.ip_allocation_policy["cluster_ipv4_cidr_block"]
+    cluster_secondary_range_name  = var.ip_allocation_policy["cluster_secondary_range_name"]
+    services_ipv4_cidr_block      = var.ip_allocation_policy["services_ipv4_cidr_block"]
+    services_secondary_range_name = var.ip_allocation_policy["services_secondary_range_name"]
+  }
+}
+
+
+resource "google_container_cluster" "success" {
+  name               = var.name
+  location           = var.location
+  initial_node_count = 1
+  project            = data.google_project.project.name
+
+  network    = var.network
+  subnetwork = var.subnetwork
+
+  ip_allocation_policy {
+    cluster_ipv4_cidr_block       = var.ip_allocation_policy["cluster_ipv4_cidr_block"]
+    cluster_secondary_range_name  = var.ip_allocation_policy["cluster_secondary_range_name"]
+    services_ipv4_cidr_block      = var.ip_allocation_policy["services_ipv4_cidr_block"]
+    services_secondary_range_name = var.ip_allocation_policy["services_secondary_range_name"]
+  }
+
+  node_config {
+    workload_metadata_config {
+      node_metadata = "GKE_METADATA_SERVER"
+    }
+  }
+
+  release_channel {
+    channel=var.release_channel
+  }
+
+}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
1. Ensure the GKE Metadata Server is Enabled
in google_container_cluster or google_container_node_pool
node_config{
    workload_metadata_config {
    node_metadata="GKE_METADATA_SERVER"
}
}

2. When creating New Clusters - Automate GKE version management using Release Channels
property Release Channels in clusters
 release_channel {
    channel=var.release_channel
  }
  