### PR TITLE
Add CKV_AWS_127 - Ensure that Elastic Load Balancer(s) uses SSL

### DIFF
--- a/checkov/terraform/checks/resource/aws/ELBUsesSSL.py
+++ b/checkov/terraform/checks/resource/aws/ELBUsesSSL.py
@@ -1,0 +1,21 @@
+from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.terraform.checks.resource.base_resource_check import BaseResourceCheck
+
+
+class ELBUsesSSL(BaseResourceCheck):
+    def __init__(self):
+        name = "Ensure that Elastic Load Balancer(s) uses SSL certificates provided by AWS Certificate Manager"
+        id = "CKV_AWS_127"
+        supported_resources = ['aws_elb']
+        categories = [CheckCategories.GENERAL_SECURITY]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf):
+        if 'listener' in conf:
+            for listener in conf['listener']:
+                if 'ssl_certificate_id' not in listener:
+                    return CheckResult.FAILED
+        return CheckResult.PASSED
+
+
+check = ELBUsesSSL()

--- a/tests/terraform/checks/resource/aws/test_ELBUsesSSL.py
+++ b/tests/terraform/checks/resource/aws/test_ELBUsesSSL.py
@@ -1,0 +1,116 @@
+import unittest
+import hcl2
+
+from checkov.terraform.checks.resource.aws.ELBUsesSSL import check
+from checkov.common.models.enums import CheckResult
+
+
+class TestELBUsesSSL(unittest.TestCase):
+
+    def test_failure_elb_one_listener(self):
+        hcl_res = hcl2.loads("""
+          resource "aws_elb" "test" {
+              name               = "foobar-terraform-elb"
+              availability_zones = ["us-west-2a", "us-west-2b", "us-west-2c"]
+            
+              listener {
+                instance_port     = 8000
+                instance_protocol = "http"
+                lb_port           = 80
+                lb_protocol       = "http"
+              }
+            
+              health_check {
+                healthy_threshold   = 2
+                unhealthy_threshold = 2
+                timeout             = 3
+                target              = "HTTP:8000/"
+                interval            = 30
+              }
+            
+              instances                   = [aws_instance.foo.id]
+              cross_zone_load_balancing   = true
+              idle_timeout                = 400
+              connection_draining         = true
+              connection_draining_timeout = 400
+          }
+        """)
+        resource_conf = hcl_res['resource'][0]['aws_elb']['test']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_failure_elb_multi_listener(self):
+        hcl_res = hcl2.loads("""
+          resource "aws_elb" "test" {
+              name               = "foobar-terraform-elb"
+              availability_zones = ["us-west-2a", "us-west-2b", "us-west-2c"]
+
+              listener {
+                instance_port     = 8000
+                instance_protocol = "http"
+                lb_port           = 80
+                lb_protocol       = "http"
+              }
+              listener {
+                instance_port      = 8000
+                instance_protocol  = "http"
+                lb_port            = 443
+                lb_protocol        = "https"
+                ssl_certificate_id = "arn:aws:iam::123456789012:server-certificate/certName"
+              }    
+
+              health_check {
+                healthy_threshold   = 2
+                unhealthy_threshold = 2
+                timeout             = 3
+                target              = "HTTP:8000/"
+                interval            = 30
+              }
+
+              instances                   = [aws_instance.foo.id]
+              cross_zone_load_balancing   = true
+              idle_timeout                = 400
+              connection_draining         = true
+              connection_draining_timeout = 400
+          }
+        """)
+        resource_conf = hcl_res['resource'][0]['aws_elb']['test']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_success_elb(self):
+        hcl_res = hcl2.loads("""
+        resource "aws_elb" "test" {
+          name               = "foobar-terraform-elb"
+          availability_zones = ["us-west-2a", "us-west-2b", "us-west-2c"]
+          
+          listener {
+            instance_port      = 8000
+            instance_protocol  = "http"
+            lb_port            = 443
+            lb_protocol        = "https"
+            ssl_certificate_id = "arn:aws:iam::123456789012:server-certificate/certName"
+          }           
+        
+          health_check {
+            healthy_threshold   = 2
+            unhealthy_threshold = 2
+            timeout             = 3
+            target              = "HTTP:8000/"
+            interval            = 30
+          }
+        
+          instances                   = [aws_instance.foo.id]
+          cross_zone_load_balancing   = true
+          idle_timeout                = 400
+          connection_draining         = true
+          connection_draining_timeout = 400
+        }
+        """)
+        resource_conf = hcl_res['resource'][0]['aws_elb']['test']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/terraform/runner/test_plan_runner.py
+++ b/tests/terraform/runner/test_plan_runner.py
@@ -118,7 +118,7 @@ class TestRunnerValid(unittest.TestCase):
         self.assertEqual(report.get_exit_code(soft_fail=True), 0)
 
         self.assertEqual(62, report.get_summary()["failed"])
-        self.assertEqual(65, report.get_summary()["passed"])
+        self.assertEqual(66, report.get_summary()["passed"])
 
         files_scanned = list(set(map(lambda rec: rec.file_path, report.failed_checks)))
         self.assertGreaterEqual(5, len(files_scanned))


### PR DESCRIPTION
Ensure that Elastic Load Balancer(s) uses SSL certificates provided by AWS Certificate Manager.
