### PR TITLE
Expose option to re-use graph when running the scan

### DIFF
--- a/checkov/terraform/runner.py
+++ b/checkov/terraform/runner.py
@@ -83,10 +83,10 @@ class Runner(BaseRunner):
 
         return report
 
-    def check_tf_definition(self, report, root_folder, runner_filter, collect_skip_comments=True, external_definitions_context=None):
+    def check_tf_definition(self, report, root_folder, runner_filter, collect_skip_comments=True, definitions_context=None):
         parser_registry.reset_definitions_context()
-        if external_definitions_context:
-            definitions_context = external_definitions_context
+        if definitions_context:
+            definitions_context = definitions_context
         else:
             definitions_context = {}
             for definition in self.tf_definitions.items():

--- a/tests/terraform/runner/test_runner.py
+++ b/tests/terraform/runner/test_runner.py
@@ -414,7 +414,7 @@ class TestRunnerValid(unittest.TestCase):
         runner.tf_definitions = tf_definitions
         parser.parse_directory(tf_dir_path, tf_definitions)
         report = Report('terraform')
-        runner.check_tf_definition(root_folder=tf_dir_path, report=report, runner_filter=RunnerFilter(), external_definitions_context=external_definitions_context)
+        runner.check_tf_definition(root_folder=tf_dir_path, report=report, runner_filter=RunnerFilter(), definitions_context=external_definitions_context)
         self.assertGreaterEqual(len(report.passed_checks), 1)
 
     def test_failure_in_resolved_module(self):


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

1. Allow creating definitions context and passing the context & tf_definitions to the tf_runner for scans on persistant graph
2. Fix overriding the local_graph class