### PR TITLE
CKV_K8S_72 k8s api server kubelet client cert/key

### DIFF
--- a/checkov/kubernetes/checks/ApiServerKubeletClientCertAndKey.py
+++ b/checkov/kubernetes/checks/ApiServerKubeletClientCertAndKey.py
@@ -1,0 +1,30 @@
+from checkov.common.models.enums import CheckCategories, CheckResult
+from checkov.kubernetes.base_spec_check import BaseK8Check
+
+class ApiServerKubeletClientCertAndKey(BaseK8Check):
+    def __init__(self):
+        # CIS-1.6 1.2.5
+        id = "CKV_K8S_72"
+        name = "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate"
+        categories = [CheckCategories.KUBERNETES]
+        supported_entities = ['containers']
+        super().__init__(name=name, id=id, categories=categories, supported_entities=supported_entities)
+
+    def get_resource_id(self, conf):
+        return f'{conf["parent"]} - {conf["name"]}'
+
+    def scan_spec_conf(self, conf):
+        if conf.get("command") is not None:
+            if "kube-apiserver" in conf["command"]:
+                hasCertCommand = False
+                hasKeyCommand = False
+                for command in conf["command"]:
+                    if command.startswith("--kubelet-client-certificate"):
+                        hasCertCommand = True
+                    elif command.startswith("--kubelet-client-key"):
+                        hasKeyCommand = True
+                return CheckResult.PASSED if hasCertCommand and hasKeyCommand else CheckResult.FAILED
+           
+        return CheckResult.PASSED
+
+check = ApiServerKubeletClientCertAndKey()

--- a/tests/kubernetes/checks/example_ApiServerKubeletClientCertAndKey/ApiServer-FAILED-2.yaml
+++ b/tests/kubernetes/checks/example_ApiServerKubeletClientCertAndKey/ApiServer-FAILED-2.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    component: kube-apiserver
+    tier: control-plane
+  name: kube-apiserver
+  namespace: kube-system
+spec:
+  containers:
+  - command:
+    - kube-apiserver
+    image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+    livenessProbe:
+      failureThreshold: 8
+      httpGet:
+        host: 127.0.0.1
+        path: /healthz
+        port: 6443
+        scheme: HTTPS
+      initialDelaySeconds: 15
+      timeoutSeconds: 15
+    name: kube-apiserver-should-fail
+    resources:
+      requests:
+        cpu: 250m
+    volumeMounts:
+    - mountPath: /etc/kubernetes/
+      name: k8s
+      readOnly: true
+    - mountPath: /etc/ssl/certs
+      name: certs
+    - mountPath: /etc/pki
+      name: pki
+  hostNetwork: true
+  volumes:
+  - hostPath:
+      path: /etc/kubernetes
+    name: k8s
+  - hostPath:
+      path: /etc/ssl/certs
+    name: certs
+  - hostPath:
+      path: /etc/pki
+    name: pki

--- a/tests/kubernetes/checks/example_ApiServerKubeletClientCertAndKey/ApiServer-FAILED.yaml
+++ b/tests/kubernetes/checks/example_ApiServerKubeletClientCertAndKey/ApiServer-FAILED.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    component: kube-apiserver
+    tier: control-plane
+  name: kube-apiserver
+  namespace: kube-system
+spec:
+  containers:
+  - command:
+    - kube-apiserver
+    - --kubelet-client-certificate=/path/to/cert
+    image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+    livenessProbe:
+      failureThreshold: 8
+      httpGet:
+        host: 127.0.0.1
+        path: /healthz
+        port: 6443
+        scheme: HTTPS
+      initialDelaySeconds: 15
+      timeoutSeconds: 15
+    name: kube-apiserver-should-fail
+    resources:
+      requests:
+        cpu: 250m
+    volumeMounts:
+    - mountPath: /etc/kubernetes/
+      name: k8s
+      readOnly: true
+    - mountPath: /etc/ssl/certs
+      name: certs
+    - mountPath: /etc/pki
+      name: pki
+  hostNetwork: true
+  volumes:
+  - hostPath:
+      path: /etc/kubernetes
+    name: k8s
+  - hostPath:
+      path: /etc/ssl/certs
+    name: certs
+  - hostPath:
+      path: /etc/pki
+    name: pki

--- a/tests/kubernetes/checks/example_ApiServerKubeletClientCertAndKey/ApiServer-PASSED.yaml
+++ b/tests/kubernetes/checks/example_ApiServerKubeletClientCertAndKey/ApiServer-PASSED.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    component: kube-apiserver
+    tier: control-plane
+  name: kube-apiserver
+  namespace: kube-system
+spec:
+  containers:
+  - command:
+    - kube-apiserver
+    - --kubelet-client-certificate=/path/to/cert
+    - --kubelet-client-key=/path/to/key
+    image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+    livenessProbe:
+      failureThreshold: 8
+      httpGet:
+        host: 127.0.0.1
+        path: /healthz
+        port: 6443
+        scheme: HTTPS
+      initialDelaySeconds: 15
+      timeoutSeconds: 15
+    name: kube-apiserver-should-pass
+    resources:
+      requests:
+        cpu: 250m
+    volumeMounts:
+    - mountPath: /etc/kubernetes/
+      name: k8s
+      readOnly: true
+    - mountPath: /etc/ssl/certs
+      name: certs
+    - mountPath: /etc/pki
+      name: pki
+  hostNetwork: true
+  volumes:
+  - hostPath:
+      path: /etc/kubernetes
+    name: k8s
+  - hostPath:
+      path: /etc/ssl/certs
+    name: certs
+  - hostPath:
+      path: /etc/pki
+    name: pki

--- a/tests/kubernetes/checks/test_ApiServerKubeletClientCertAndKey.py
+++ b/tests/kubernetes/checks/test_ApiServerKubeletClientCertAndKey.py
@@ -12,7 +12,7 @@ class TestApiServerKubeletClientCertAndKey(unittest.TestCase):
         runner = Runner()
         current_dir = os.path.dirname(os.path.realpath(__file__))
 
-        test_files_dir = current_dir + "/ApiServerKubeletClientCertAndKey"
+        test_files_dir = current_dir + "/example_ApiServerKubeletClientCertAndKey"
         report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
         summary = report.get_summary()
 

--- a/tests/kubernetes/checks/test_ApiServerKubeletClientCertAndKey.py
+++ b/tests/kubernetes/checks/test_ApiServerKubeletClientCertAndKey.py
@@ -1,0 +1,31 @@
+import os
+import unittest
+
+from checkov.kubernetes.checks.ApiServerKubeletClientCertAndKey import check
+from checkov.kubernetes.runner import Runner
+from checkov.runner_filter import RunnerFilter
+
+
+class TestApiServerKubeletClientCertAndKey(unittest.TestCase):
+
+    def test_summary(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/ApiServerKubeletClientCertAndKey"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        self.assertEqual(summary['passed'], 1)
+        self.assertEqual(summary['failed'], 2)
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+
+        for failed in report.failed_checks:
+            self.assertTrue("should-fail" in failed.resource)
+        for passed in report.passed_checks:
+            self.assertTrue("should-pass" in passed.resource)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate
Id = CKV_K8S_72

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
