### PR TITLE
CKV2_AWS_5

### DIFF
--- a/checkov/graph/terraform/checks/aws/SGToEC2AndENI.yaml
+++ b/checkov/graph/terraform/checks/aws/SGToEC2AndENI.yaml
@@ -1,0 +1,21 @@
+metadata:
+  name: "Ensure that Security Groups are attached to EC2 instances or elastic network interfaces (ENIs)"
+  id: "CKV2_AWS_5"
+  category: "NETWORKING"
+scope:
+  provider: "AWS"
+definition:
+  and:
+    - cond_type: filter
+      attribute: resource_type
+      value:
+        - aws_security_group
+      operator: within
+    - resource_types:
+      - aws_security_group
+      connected_resource_types:
+        - aws_instance
+        - aws_network_interface
+      operator:  exists
+      attribute: networking
+      cond_type: connection

--- a/tests/graph/terraform/checks/resources/SGToEC2AndENI/expected.yaml
+++ b/tests/graph/terraform/checks/resources/SGToEC2AndENI/expected.yaml
@@ -1,0 +1,4 @@
+pass:
+  - "aws_security_group.ok_sg"
+fail:
+  - "aws_security_group.not_ok_sg"

--- a/tests/graph/terraform/checks/resources/SGToEC2AndENI/main.tf
+++ b/tests/graph/terraform/checks/resources/SGToEC2AndENI/main.tf
@@ -1,0 +1,30 @@
+resource "aws_network_interface" "test" {
+  subnet_id       = "aws_subnet.public_a.id"
+  security_groups = [aws_security_group.ok_sg.id]
+}
+
+resource "aws_instance" "test" {
+  ami           = "data.aws_ami.ubuntu.id"
+  instance_type = "t3.micro"
+  security_groups = [aws_security_group.ok_sg.id]
+}
+
+resource "aws_security_group" "ok_sg" {
+  ingress {
+    description = "TLS from VPC"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = 0.0.0.0/0
+  }
+}
+
+resource "aws_security_group" "not_ok_sg" {
+  ingress {
+    description = "TLS from VPC"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = 0.0.0.0/0
+  }
+}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
CKV2_AWS_5 - Ensure that Security Groups are attached to EC2 instances or elastic network interfaces (ENIs)