### PR TITLE
CKV_GCP_67 Ensure legacy Compute Engine instance metadata APIs are Disabled 

### DIFF
--- a/checkov/common/util/type_forcers.py
+++ b/checkov/common/util/type_forcers.py
@@ -12,6 +12,13 @@ def force_int (var):
     except:
         return None
 
+def force_float (var):
+    try:
+        if not isinstance(var, float):
+            var = float(var)
+        return var
+    except:
+        return None
 
 def convert_str_to_bool(bool_str):
     if bool_str in ['true', '"true"', 'True', '"True"']:

--- a/checkov/terraform/checks/resource/gcp/GKELegacyInstanceMetadataDisabled.py
+++ b/checkov/terraform/checks/resource/gcp/GKELegacyInstanceMetadataDisabled.py
@@ -1,0 +1,33 @@
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from checkov.common.models.enums import CheckResult, CheckCategories
+
+class GKELegacyInstanceMetadataDisabled(BaseResourceValueCheck):
+
+    def __init__(self):
+        name = "Ensure legacy Compute Engine instance metadata APIs are Disabled"
+        id = "CKV_GCP_67"
+        supported_resources = ['google_container_cluster']
+        categories = [CheckCategories.KUBERNETES]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+ 
+    def scan_resource_conf(self, conf):
+        """
+        looks for min_master_version =1.12 which ensures that legacy metadata endpoints are disabled
+        https://www.terraform.io/docs/providers/google/r/compute_ssl_policy.html
+        :param conf: google_container_cluster configuration
+        :return: <CheckResult>
+        """
+        if 'min_master_version' in conf: 
+            min_master_version = conf.get('min_master_version')[0]
+            if float(min_master_version) >= 1.12:
+                return CheckResult.PASSED
+        
+        return CheckResult.FAILED
+        
+    def get_inspected_key(self):
+        return 'min_master_version'
+
+    def get_expected_value(self):
+        return "1.12"
+
+check = GKELegacyInstanceMetadataDisabled()

--- a/checkov/terraform/checks/resource/gcp/GKELegacyInstanceMetadataDisabled.py
+++ b/checkov/terraform/checks/resource/gcp/GKELegacyInstanceMetadataDisabled.py
@@ -1,5 +1,6 @@
 from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
 from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.common.util.type_forcers import force_float
 
 class GKELegacyInstanceMetadataDisabled(BaseResourceValueCheck):
 
@@ -19,7 +20,7 @@ class GKELegacyInstanceMetadataDisabled(BaseResourceValueCheck):
         """
         if 'min_master_version' in conf: 
             min_master_version = conf.get('min_master_version')[0]
-            if float(min_master_version) >= 1.12:
+            if force_float(min_master_version) >= 1.12:
                 return CheckResult.PASSED
         
         return CheckResult.FAILED

--- a/tests/terraform/checks/resource/gcp/test_GKELegacyInstanceMetadataDisabled.py
+++ b/tests/terraform/checks/resource/gcp/test_GKELegacyInstanceMetadataDisabled.py
@@ -1,0 +1,41 @@
+import unittest
+import os
+
+from checkov.terraform.checks.resource.gcp.GKELegacyInstanceMetadataDisabled import check
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.runner import Runner
+
+
+class TestGKELegacyInstanceMetadataDisabled(unittest.TestCase):
+
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/test_GKELegacyInstanceMetadataDisabled"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            'google_container_cluster.success1',
+            'google_container_cluster.success2',
+        }
+        failing_resources = {
+            'google_container_cluster.fail1',
+            'google_container_cluster.fail2' 
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary['passed'], 2)
+        self.assertEqual(summary['failed'], 2)
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/terraform/checks/resource/gcp/test_GKELegacyInstanceMetadataDisabled/main.tf
+++ b/tests/terraform/checks/resource/gcp/test_GKELegacyInstanceMetadataDisabled/main.tf
@@ -1,0 +1,91 @@
+
+resource "google_container_cluster" "fail1" {
+  name               = var.name
+  location           = var.location
+  initial_node_count = 1
+  project            = data.google_project.project.name
+
+  network    = var.network
+  subnetwork = var.subnetwork
+
+  ip_allocation_policy {
+    cluster_ipv4_cidr_block       = var.ip_allocation_policy["cluster_ipv4_cidr_block"]
+    cluster_secondary_range_name  = var.ip_allocation_policy["cluster_secondary_range_name"]
+    services_ipv4_cidr_block      = var.ip_allocation_policy["services_ipv4_cidr_block"]
+    services_secondary_range_name = var.ip_allocation_policy["services_secondary_range_name"]
+  }
+}
+
+resource "google_container_cluster" "fail2" {
+  name               = var.name
+  location           = var.location
+  initial_node_count = 1
+  project            = data.google_project.project.name
+
+  network    = var.network
+  subnetwork = var.subnetwork
+  min_master_version = "1.11"
+
+  ip_allocation_policy {
+    cluster_ipv4_cidr_block       = var.ip_allocation_policy["cluster_ipv4_cidr_block"]
+    cluster_secondary_range_name  = var.ip_allocation_policy["cluster_secondary_range_name"]
+    services_ipv4_cidr_block      = var.ip_allocation_policy["services_ipv4_cidr_block"]
+    services_secondary_range_name = var.ip_allocation_policy["services_secondary_range_name"]
+  }
+
+  node_config {
+    workload_metadata_config {
+      node_metadata = "GKE_METADATA_SERVER"
+    }
+  }
+}
+
+
+resource "google_container_cluster" "success1" {
+  name               = var.name
+  location           = var.location
+  initial_node_count = 1
+  project            = data.google_project.project.name
+
+  network    = var.network
+  subnetwork = var.subnetwork
+  min_master_version = 1.12
+
+  ip_allocation_policy {
+    cluster_ipv4_cidr_block       = var.ip_allocation_policy["cluster_ipv4_cidr_block"]
+    cluster_secondary_range_name  = var.ip_allocation_policy["cluster_secondary_range_name"]
+    services_ipv4_cidr_block      = var.ip_allocation_policy["services_ipv4_cidr_block"]
+    services_secondary_range_name = var.ip_allocation_policy["services_secondary_range_name"]
+  }
+
+  node_config {
+    workload_metadata_config {
+      node_metadata = "GKE_METADATA_SERVER"
+    }
+  }
+}
+
+
+resource "google_container_cluster" "success2" {
+  name               = var.name
+  location           = var.location
+  initial_node_count = 1
+  project            = data.google_project.project.name
+
+  network    = var.network
+  subnetwork = var.subnetwork
+  min_master_version = 1.13
+
+  ip_allocation_policy {
+    cluster_ipv4_cidr_block       = var.ip_allocation_policy["cluster_ipv4_cidr_block"]
+    cluster_secondary_range_name  = var.ip_allocation_policy["cluster_secondary_range_name"]
+    services_ipv4_cidr_block      = var.ip_allocation_policy["services_ipv4_cidr_block"]
+    services_secondary_range_name = var.ip_allocation_policy["services_secondary_range_name"]
+  }
+
+  node_config {
+    workload_metadata_config {
+      node_metadata = "GKE_METADATA_SERVER"
+    }
+  }
+}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
11. Ensure legacy Compute Engine instance metadata APIs are Disabled 
"From GKE 1.12 onwards, disable-legacy-endpoints is set to true by the API"

check GKE version
By checking that min_master_version  is set to 1.12 or higher?

