### PR TITLE
Check/CKV_GCP_73 Ensure Secure Boot for Shielded GKE Nodes is Enabled

### DIFF
--- a/checkov/terraform/checks/resource/gcp/GKESecureBootforShieldedNodes.py
+++ b/checkov/terraform/checks/resource/gcp/GKESecureBootforShieldedNodes.py
@@ -1,0 +1,35 @@
+
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from checkov.common.models.enums import CheckCategories, CheckResult
+
+class GKESecureBootforShieldedNodes(BaseResourceValueCheck):
+    def __init__(self):
+        name = "Ensure Secure Boot for Shielded GKE Nodes is Enabled"
+        id = "CKV_GCP_73"
+        supported_resources = ['google_container_cluster','google_container_node_pool']
+        categories = [CheckCategories.KUBERNETES]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def scan_resource_conf(self, conf):
+        if 'node_config' in conf.keys():
+            node=conf["node_config"][0]
+            if 'shielded_instance_config' in node.keys():
+                monitor=node["shielded_instance_config"][0]
+                if monitor["enable_secure_boot"] == [True]:
+                    return CheckResult.PASSED
+                else:
+                    return CheckResult.FAILED
+            else:
+                #as default is true this is a pass 
+                return CheckResult.FAILED
+        else:
+            return CheckResult.UNKNOWN
+
+    def get_inspected_key(self):
+        return 'node_config/[0]/shielded_instance_config/[0]/enable_secure_boot'
+
+    def get_expected_values(self):
+        return [True]
+
+
+check = GKESecureBootforShieldedNodes()

--- a/tests/terraform/checks/resource/gcp/test_GKEReleaseChannel/main.tf
+++ b/tests/terraform/checks/resource/gcp/test_GKEReleaseChannel/main.tf
@@ -40,7 +40,7 @@ resource "google_container_cluster" "success" {
   }
 
   release_channel {
-    channel=var.release_channel
+    channel = var.release_channel
   }
 
 }

--- a/tests/terraform/checks/resource/gcp/test_GKESecureBootforShieldedNodes.py
+++ b/tests/terraform/checks/resource/gcp/test_GKESecureBootforShieldedNodes.py
@@ -1,0 +1,42 @@
+import unittest
+import os
+
+from checkov.terraform.checks.resource.gcp.GKESecureBootforShieldedNodes import check
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.runner import Runner
+
+class TestGKESecureBootforShieldedNodes(unittest.TestCase):
+
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/test_GKESecureBootforShieldedNodes"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            'google_container_cluster.success',
+            'google_container_node_pool.success'
+        }
+        failing_resources = {
+            'google_container_cluster.fail1',
+            'google_container_node_pool.fail1',
+            'google_container_cluster.fail2',
+            'google_container_node_pool.fail2'
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary['passed'], 3)
+        self.assertEqual(summary['failed'], 4)
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/terraform/checks/resource/gcp/test_GKESecureBootforShieldedNodes.py
+++ b/tests/terraform/checks/resource/gcp/test_GKESecureBootforShieldedNodes.py
@@ -29,7 +29,7 @@ class TestGKESecureBootforShieldedNodes(unittest.TestCase):
         passed_check_resources = set([c.resource for c in report.passed_checks])
         failed_check_resources = set([c.resource for c in report.failed_checks])
 
-        self.assertEqual(summary['passed'], 3)
+        self.assertEqual(summary['passed'], 2)
         self.assertEqual(summary['failed'], 4)
         self.assertEqual(summary['skipped'], 0)
         self.assertEqual(summary['parsing_errors'], 0)

--- a/tests/terraform/checks/resource/gcp/test_GKESecureBootforShieldedNodes/main.tf
+++ b/tests/terraform/checks/resource/gcp/test_GKESecureBootforShieldedNodes/main.tf
@@ -97,6 +97,9 @@ resource "google_container_cluster" "fail2" {
     workload_metadata_config {
       node_metadata = "GKE_METADATA_SERVER"
     }
+    shielded_instance_config {
+      enable_secure_boot = false
+    }
   }
 
   release_channel {
@@ -147,6 +150,90 @@ resource "google_container_cluster" "fail2" {
   }
 
   resource_labels = var.resource_labels
+}
+
+resource "google_container_node_pool" "fail1" {
+  project  = data.google_project.project.name
+  name     = var.node_pool["name"]
+  location = var.location
+  cluster  = google_container_cluster.cluster.name
+
+  node_count        = var.node_pool["node_count"]
+  max_pods_per_node = var.node_pool["max_pods_per_node"]
+
+  node_config {
+    machine_type = var.node_pool["machine_type"]
+    disk_size_gb = var.node_pool["disk_size_gb"]
+    disk_type    = var.node_pool["disk_type"]
+
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/compute",
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+    ]
+  }
+}
+
+resource "google_container_node_pool" "fail2" {
+  project  = data.google_project.project.name
+  name     = var.node_pool["name"]
+  location = var.location
+  cluster  = google_container_cluster.cluster.name
+
+  node_count        = var.node_pool["node_count"]
+  max_pods_per_node = var.node_pool["max_pods_per_node"]
+
+  node_config {
+    machine_type = var.node_pool["machine_type"]
+    disk_size_gb = var.node_pool["disk_size_gb"]
+    disk_type    = var.node_pool["disk_type"]
+
+    workload_metadata_config {
+      node_metadata = "GKE_METADATA_SERVER"
+    }
+    shielded_instance_config {
+      enable_secure_boot = false
+    }
+
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/compute",
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+    ]
+  }
+}
+
+resource "google_container_node_pool" "success" {
+  project  = data.google_project.project.name
+  name     = var.node_pool["name"]
+  location = var.location
+  cluster  = google_container_cluster.cluster.name
+
+  node_count        = var.node_pool["node_count"]
+  max_pods_per_node = var.node_pool["max_pods_per_node"]
+
+  node_config {
+    machine_type = var.node_pool["machine_type"]
+    disk_size_gb = var.node_pool["disk_size_gb"]
+    disk_type    = var.node_pool["disk_type"]
+
+    workload_metadata_config {
+      node_metadata = "GKE_METADATA_SERVER"
+    }
+
+    shielded_instance_config {
+      enable_secure_boot = true
+    }
+
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/compute",
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+    ]
+  }
 }
 
 resource "google_container_cluster" "success" {
@@ -167,11 +254,15 @@ resource "google_container_cluster" "success" {
 
   remove_default_node_pool = var.remove_default_node_pool
 
-  enable_shielded_nodes = true
+  min_master_version = "1.12"
 
   node_config {
     workload_metadata_config {
       node_metadata = "GKE_METADATA_SERVER"
+    }
+    shielded_instance_config {
+      enable_integrity_monitoring = true
+      enable_secure_boot = true
     }
   }
 
@@ -224,3 +315,5 @@ resource "google_container_cluster" "success" {
 
   resource_labels = var.resource_labels
 }
+
+

--- a/tests/terraform/checks/resource/gcp/test_GoogleCloudSqlDatabasePublicallyAccessible/main.tf
+++ b/tests/terraform/checks/resource/gcp/test_GoogleCloudSqlDatabasePublicallyAccessible/main.tf
@@ -4,7 +4,7 @@ resource "google_sql_database_instance" "instance1-fail" {
   settings {
     tier = "db-f1-micro"
     ip_configuration {
-      ipv4_enabled    = true
+      ipv4_enabled = true
       authorized_networks = [
         {
           name  = "XYZ"
@@ -15,7 +15,7 @@ resource "google_sql_database_instance" "instance1-fail" {
           value = "0.0.0.0/0"
         },
         {
-          name = "ABC",
+          name  = "ABC",
           value = "5.5.5.0/24"
         }
       ]
@@ -29,14 +29,14 @@ resource "google_sql_database_instance" "instance2-pass" {
   settings {
     tier = "db-f1-micro"
     ip_configuration {
-      ipv4_enabled    = true
+      ipv4_enabled = true
       authorized_networks = [
         {
           name  = "XYZ"
           value = "1.2.3.4"
         },
         {
-          name = "ABC",
+          name  = "ABC",
           value = "5.5.5.0/24"
         }
       ]


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
Ensure Secure Boot for Shielded GKE Nodes is Enabled
check exists and set as defaults to false
shielded_instance_config {
enable_secure_boot =true
}