### PR TITLE
CKV_AWS_137

### DIFF
--- a/checkov/terraform/checks/resource/aws/DynamodbPointInTimeRecoveryEnabled.py
+++ b/checkov/terraform/checks/resource/aws/DynamodbPointInTimeRecoveryEnabled.py
@@ -7,7 +7,7 @@ class DynamodbPointInTimeRecoveryEnabled(BaseResourceValueCheck):
         name = "Ensure that that point in time recovery is enabled for Amazon DynamoDB tables"
         id = "CKV_AWS_125"
         supported_resources = ['aws_dynamodb_table']
-        categories = [CheckCategories.NETWORKING]
+        categories = [CheckCategories.BACKUP_AND_RECOVERY]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def get_inspected_key(self):

--- a/checkov/terraform/checks/resource/aws/ElasticsearchInVPC.py
+++ b/checkov/terraform/checks/resource/aws/ElasticsearchInVPC.py
@@ -1,0 +1,22 @@
+from checkov.common.models.consts import ANY_VALUE
+from checkov.common.models.enums import CheckResult, CheckCategories
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+
+
+class LambdaInVPC(BaseResourceValueCheck):
+
+    def __init__(self):
+        name = "Ensure that Elasticsearch is configured inside a VPC"
+        id = "CKV_AWS_137"
+        supported_resources = ['aws_elasticsearch_domain']
+        categories = [CheckCategories.NETWORKING]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self):
+        return "vpc_options"
+
+    def get_expected_value(self):
+        return ANY_VALUE
+
+
+check = LambdaInVPC()

--- a/checkov/terraform/checks/resource/aws/ElasticsearchInVPC.py
+++ b/checkov/terraform/checks/resource/aws/ElasticsearchInVPC.py
@@ -3,7 +3,7 @@ from checkov.common.models.enums import CheckResult, CheckCategories
 from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
 
 
-class LambdaInVPC(BaseResourceValueCheck):
+class ElasticsearchInVPC(BaseResourceValueCheck):
 
     def __init__(self):
         name = "Ensure that Elasticsearch is configured inside a VPC"
@@ -19,4 +19,4 @@ class LambdaInVPC(BaseResourceValueCheck):
         return ANY_VALUE
 
 
-check = LambdaInVPC()
+check = ElasticsearchInVPC()

--- a/tests/terraform/checks/resource/aws/test_ElasticsearchInVPC.py
+++ b/tests/terraform/checks/resource/aws/test_ElasticsearchInVPC.py
@@ -6,7 +6,7 @@ from checkov.common.models.enums import CheckResult
 import hcl2
 
 
-class TestLambdaInVPC(unittest.TestCase):
+class TestElasticsearchInVPC(unittest.TestCase):
 
     def test_failure(self):
         hcl_res = hcl2.loads("""

--- a/tests/terraform/checks/resource/aws/test_ElasticsearchInVPC.py
+++ b/tests/terraform/checks/resource/aws/test_ElasticsearchInVPC.py
@@ -1,0 +1,53 @@
+import unittest
+
+from checkov.terraform.checks.resource.aws.ElasticsearchInVPC import check
+from checkov.common.models.enums import CheckResult
+
+import hcl2
+
+
+class TestLambdaInVPC(unittest.TestCase):
+
+    def test_failure(self):
+        hcl_res = hcl2.loads("""
+        resource "aws_elasticsearch_domain" "es" {
+          domain_name           = var.domain
+          elasticsearch_version = "6.3"
+        
+          cluster_config {
+            instance_type = "m4.large.elasticsearch"
+          }
+        }
+        """)
+        resource_conf = hcl_res['resource'][0]['aws_elasticsearch_domain']['es']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_success(self):
+        hcl_res = hcl2.loads("""
+        resource "aws_elasticsearch_domain" "es" {
+          domain_name           = var.domain
+          elasticsearch_version = "6.3"
+        
+          cluster_config {
+            instance_type = "m4.large.elasticsearch"
+          }
+        
+          vpc_options {
+            subnet_ids = [
+              data.aws_subnet_ids.selected.ids[0],
+              data.aws_subnet_ids.selected.ids[1],
+            ]
+        
+            security_group_ids = [aws_security_group.es.id]
+          }
+        
+        }
+        """)
+        resource_conf = hcl_res['resource'][0]['aws_elasticsearch_domain']['es']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
Implement CKV_AWS_137 and modify the category in CKV_AWS_125 (after consult to Gilad)
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticsearch_domain
Ensure that Elasticsearch is configured inside a VPC