### PR TITLE
CKV_AWS_145

### DIFF
--- a/checkov/terraform/checks/resource/aws/S3KMSEncryptedByDefault.py
+++ b/checkov/terraform/checks/resource/aws/S3KMSEncryptedByDefault.py
@@ -1,0 +1,21 @@
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from checkov.common.models.enums import CheckCategories
+
+
+class S3KMSEncryptedByDefault(BaseResourceValueCheck):
+    def __init__(self):
+        name = "Ensure that S3 buckets are encrypted with KMS by default"
+        id = "CKV_AWS_145"
+        supported_resources = ['aws_s3_bucket']
+        categories = [CheckCategories.ENCRYPTION]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self):
+        return "server_side_encryption_configuration/[0]/rule/[0]/" \
+               "apply_server_side_encryption_by_default/[0]/sse_algorithm"
+
+    def get_expected_value(self):
+        return 'aws:kms'
+
+
+check = S3KMSEncryptedByDefault()

--- a/tests/terraform/checks/resource/aws/test_S3KMSEncryptedByDefault.py
+++ b/tests/terraform/checks/resource/aws/test_S3KMSEncryptedByDefault.py
@@ -1,0 +1,59 @@
+import unittest
+
+import hcl2
+
+from checkov.common.models.enums import CheckResult
+from checkov.terraform.checks.resource.aws.S3KMSEncryptedByDefault import check
+
+
+class TestS3KMSEncryptedByDefault(unittest.TestCase):
+
+    def test_failure1(self):
+        hcl_res = hcl2.loads("""
+        resource "aws_s3_bucket" "mybucket" {
+          bucket = "mybucket"
+        }
+        """)
+        resource_conf = hcl_res['resource'][0]['aws_s3_bucket']['mybucket']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_failure2(self):
+        hcl_res = hcl2.loads("""
+        resource "aws_s3_bucket" "mybucket" {
+          bucket = "mybucket"
+        
+          server_side_encryption_configuration {
+            rule {
+              apply_server_side_encryption_by_default {
+                sse_algorithm     = "AES256"
+              }
+            }
+          }
+        }
+        """)
+        resource_conf = hcl_res['resource'][0]['aws_s3_bucket']['mybucket']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_success(self):
+        hcl_res = hcl2.loads("""
+            resource "aws_s3_bucket" "mybucket" {
+              bucket = "mybucket"
+            
+              server_side_encryption_configuration {
+                rule {
+                  apply_server_side_encryption_by_default {
+                    kms_master_key_id = aws_kms_key.mykey.arn
+                    sse_algorithm     = "aws:kms"
+                  }
+                }
+              }
+            }
+        """)
+        resource_conf = hcl_res['resource'][0]['aws_s3_bucket']['mybucket']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
Ensure that S3 buckets are encrypted with KMS by default
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#apply_server_side_encryption_by_default