### PR TITLE
Add check CKV_AWS_147 

### DIFF
--- a/checkov/terraform/checks/resource/aws/RedshiftClusterAllowVersionUpgrade.py
+++ b/checkov/terraform/checks/resource/aws/RedshiftClusterAllowVersionUpgrade.py
@@ -1,0 +1,19 @@
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from checkov.common.models.enums import CheckCategories
+from checkov.common.models.enums import CheckResult
+
+
+class RedshiftClusterAllowVersionUpgrade(BaseResourceValueCheck):
+    def __init__(self):
+        name = "Ensured that redshift cluster allowing version upgrade by default"
+        id = "CKV_AWS_147"
+        supported_resources = ['aws_redshift_cluster']
+        categories = [CheckCategories.GENERAL_SECURITY]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources,
+                         missing_block_result=CheckResult.PASSED)
+
+    def get_inspected_key(self):
+        return "allow_version_upgrade"
+
+
+check = RedshiftClusterAllowVersionUpgrade()

--- a/tests/terraform/checks/resource/aws/test_RedshiftClusterAllowVersionUpgrade.py
+++ b/tests/terraform/checks/resource/aws/test_RedshiftClusterAllowVersionUpgrade.py
@@ -1,0 +1,60 @@
+import unittest
+
+import hcl2
+
+from checkov.terraform.checks.resource.aws.RedshiftClusterAllowVersionUpgrade import check
+from checkov.common.models.enums import CheckResult
+
+
+class TestRedshiftClusterAllowVersionUpgrade(unittest.TestCase):
+
+    def test_failure(self):
+        hcl_res = hcl2.loads("""
+               resource "aws_redshift_cluster" "default" {
+                  cluster_identifier = "tf-redshift-cluster"
+                  database_name      = "mydb"
+                  master_username    = "foo"
+                  master_password    = "Mustbe8characters"
+                  node_type          = "dc1.large"
+                  cluster_type       = "single-node"
+                  allow_version_upgrade = false
+                }
+                """)
+        resource_conf = hcl_res['resource'][0]['aws_redshift_cluster']['default']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_success_missing_attribute(self):
+        hcl_res = hcl2.loads("""
+                   resource "aws_redshift_cluster" "default" {
+                      cluster_identifier = "tf-redshift-cluster"
+                      database_name      = "mydb"
+                      master_username    = "foo"
+                      master_password    = "Mustbe8characters"
+                      node_type          = "dc1.large"
+                      cluster_type       = "single-node"
+                    }
+                   """)
+        resource_conf = hcl_res['resource'][0]['aws_redshift_cluster']['default']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+    def test_success(self):
+        hcl_res = hcl2.loads("""
+               resource "aws_redshift_cluster" "default" {
+                  cluster_identifier = "tf-redshift-cluster"
+                  database_name      = "mydb"
+                  master_username    = "foo"
+                  master_password    = "Mustbe8characters"
+                  node_type          = "dc1.large"
+                  cluster_type       = "single-node"
+                  allow_version_upgrade = true
+                }
+                """)
+        resource_conf = hcl_res['resource'][0]['aws_redshift_cluster']['default']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Add check CKV_AWS_147 - Ensured that redshift cluster allowing version upgrade by default

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
