### PR TITLE
CKV_GCP_64 Check/Ensure clusters are created with Private Nodes

### DIFF
--- a/checkov/terraform/checks/resource/gcp/GKEPrivateNodes.py
+++ b/checkov/terraform/checks/resource/gcp/GKEPrivateNodes.py
@@ -1,0 +1,21 @@
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from checkov.common.models.enums import CheckCategories
+from checkov.common.models.consts import ANY_VALUE
+
+
+class GKEPrivateNodes(BaseResourceValueCheck):
+    def __init__(self):
+        name = "Ensure clusters are created with Private Nodes"
+        id = "CKV_GCP_64"
+        supported_resources = ['google_container_cluster']
+        categories = [CheckCategories.KUBERNETES]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self):
+        return 'private_cluster_config'
+
+    def get_expected_values(self):
+        return [ANY_VALUE]
+
+
+check = GKEPrivateNodes()

--- a/tests/terraform/checks/resource/gcp/test_GKEPrivateNodes.py
+++ b/tests/terraform/checks/resource/gcp/test_GKEPrivateNodes.py
@@ -1,7 +1,7 @@
 import unittest
 import os
 
-from checkov.terraform.checks.resource.gcp.GKEReleaseChannel import check
+from checkov.terraform.checks.resource.gcp.GKEPrivateNodes import check
 from checkov.runner_filter import RunnerFilter
 from checkov.terraform.runner import Runner
 

--- a/tests/terraform/checks/resource/gcp/test_GKEPrivateNodes.py
+++ b/tests/terraform/checks/resource/gcp/test_GKEPrivateNodes.py
@@ -1,0 +1,39 @@
+import unittest
+import os
+
+from checkov.terraform.checks.resource.gcp.GKEReleaseChannel import check
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.runner import Runner
+
+
+class TestGKEPrivateNodes(unittest.TestCase):
+
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/test_GKEPrivateNodes"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            'google_container_cluster.success'
+        }
+        failing_resources = {
+            'google_container_cluster.fail'
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary['passed'], 1)
+        self.assertEqual(summary['failed'], 1)
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/terraform/checks/resource/gcp/test_GKEPrivateNodes/main.tf
+++ b/tests/terraform/checks/resource/gcp/test_GKEPrivateNodes/main.tf
@@ -1,0 +1,39 @@
+
+resource "google_container_cluster" "fail" {
+  name               = var.name
+  location           = var.location
+  initial_node_count = 1
+  project            = data.google_project.project.name
+
+  network    = var.network
+  subnetwork = var.subnetwork
+}
+
+
+resource "google_container_cluster" "success" {
+  name               = var.name
+  location           = var.location
+  initial_node_count = 1
+  project            = data.google_project.project.name
+
+  network    = var.network
+  subnetwork = var.subnetwork
+
+  ip_allocation_policy {
+    cluster_ipv4_cidr_block       = var.ip_allocation_policy["cluster_ipv4_cidr_block"]
+    cluster_secondary_range_name  = var.ip_allocation_policy["cluster_secondary_range_name"]
+    services_ipv4_cidr_block      = var.ip_allocation_policy["services_ipv4_cidr_block"]
+    services_secondary_range_name = var.ip_allocation_policy["services_secondary_range_name"]
+  }
+
+  node_config {
+    workload_metadata_config {
+      node_metadata = "GKE_METADATA_SERVER"
+    }
+  }
+
+  release_channel {
+    channel = var.release_channel
+  }
+
+}

--- a/tests/terraform/checks/resource/gcp/test_GKEPrivateNodes/main.tf
+++ b/tests/terraform/checks/resource/gcp/test_GKEPrivateNodes/main.tf
@@ -19,6 +19,12 @@ resource "google_container_cluster" "success" {
   network    = var.network
   subnetwork = var.subnetwork
 
+  private_cluster_config {
+    enable_private_nodes    = var.private_cluster_config["enable_private_nodes"]
+    enable_private_endpoint = var.private_cluster_config["enable_private_endpoint"]
+    master_ipv4_cidr_block  = var.private_cluster_config["master_ipv4_cidr_block"]
+  }
+
   ip_allocation_policy {
     cluster_ipv4_cidr_block       = var.ip_allocation_policy["cluster_ipv4_cidr_block"]
     cluster_secondary_range_name  = var.ip_allocation_policy["cluster_secondary_range_name"]


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
Ensure clusters are created with Private Nodes
https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters
Looks for private_cluster_config in google_container_cluster