### PR TITLE
CKV_GCP_65:Manage Kubernetes RBAC users with Google Groups for GKE

### DIFF
--- a/checkov/terraform/checks/resource/gcp/GKEKubernetesRBACGoogleGroups.py
+++ b/checkov/terraform/checks/resource/gcp/GKEKubernetesRBACGoogleGroups.py
@@ -1,0 +1,21 @@
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from checkov.common.models.enums import CheckCategories
+from checkov.common.models.consts import ANY_VALUE
+
+
+class GKEKubernetesRBACGoogleGroups(BaseResourceValueCheck):
+    def __init__(self):
+        name = "Manage Kubernetes RBAC users with Google Groups for GKE"
+        id = "CKV_GCP_65"
+        supported_resources = ['google_container_cluster']
+        categories = [CheckCategories.KUBERNETES]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self):
+        return 'authenticator_groups_config/[0]/security_group'
+
+    def get_expected_values(self):
+        return [ANY_VALUE]
+
+
+check = GKEKubernetesRBACGoogleGroups()

--- a/tests/terraform/checks/resource/gcp/test_GKEKubernetesRBACGoogleGroups.py
+++ b/tests/terraform/checks/resource/gcp/test_GKEKubernetesRBACGoogleGroups.py
@@ -1,0 +1,39 @@
+import unittest
+import os
+
+from checkov.terraform.checks.resource.gcp.GKEKubernetesRBACGoogleGroups import check
+from checkov.runner_filter import RunnerFilter
+from checkov.terraform.runner import Runner
+
+
+class TestGKEKubernetesRBACGoogleGroups(unittest.TestCase):
+
+    def test(self):
+        runner = Runner()
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        test_files_dir = current_dir + "/test_GKEKubernetesRBACGoogleGroups"
+        report = runner.run(root_folder=test_files_dir, runner_filter=RunnerFilter(checks=[check.id]))
+        summary = report.get_summary()
+
+        passing_resources = {
+            'google_container_cluster.success'
+        }
+        failing_resources = {
+            'google_container_cluster.fail',
+        }
+
+        passed_check_resources = set([c.resource for c in report.passed_checks])
+        failed_check_resources = set([c.resource for c in report.failed_checks])
+
+        self.assertEqual(summary['passed'], 1)
+        self.assertEqual(summary['failed'], 1)
+        self.assertEqual(summary['skipped'], 0)
+        self.assertEqual(summary['parsing_errors'], 0)
+
+        self.assertEqual(passing_resources, passed_check_resources)
+        self.assertEqual(failing_resources, failed_check_resources)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/terraform/checks/resource/gcp/test_GKEKubernetesRBACGoogleGroups/main.tf
+++ b/tests/terraform/checks/resource/gcp/test_GKEKubernetesRBACGoogleGroups/main.tf
@@ -1,0 +1,50 @@
+
+resource "google_container_cluster" "fail" {
+  name               = var.name
+  location           = var.location
+  initial_node_count = 1
+  project            = data.google_project.project.name
+
+  network    = var.network
+  subnetwork = var.subnetwork
+
+  ip_allocation_policy {
+    cluster_ipv4_cidr_block       = var.ip_allocation_policy["cluster_ipv4_cidr_block"]
+    cluster_secondary_range_name  = var.ip_allocation_policy["cluster_secondary_range_name"]
+    services_ipv4_cidr_block      = var.ip_allocation_policy["services_ipv4_cidr_block"]
+    services_secondary_range_name = var.ip_allocation_policy["services_secondary_range_name"]
+  }
+}
+
+
+resource "google_container_cluster" "success" {
+  name               = var.name
+  location           = var.location
+  initial_node_count = 1
+  project            = data.google_project.project.name
+
+  network    = var.network
+  subnetwork = var.subnetwork
+
+  ip_allocation_policy {
+    cluster_ipv4_cidr_block       = var.ip_allocation_policy["cluster_ipv4_cidr_block"]
+    cluster_secondary_range_name  = var.ip_allocation_policy["cluster_secondary_range_name"]
+    services_ipv4_cidr_block      = var.ip_allocation_policy["services_ipv4_cidr_block"]
+    services_secondary_range_name = var.ip_allocation_policy["services_secondary_range_name"]
+  }
+
+  authenticator_groups_config{
+    security_group="gke-security-groups@yourdomain.com"
+  }
+
+  node_config {
+    workload_metadata_config {
+      node_metadata = "GKE_METADATA_SERVER"
+    }
+  }
+
+  release_channel {
+    channel = var.release_channel
+  }
+
+}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control

CKV_GCP_65
The authenticator_groups_config block supports:
security_group 
check that this field has any value.