### PR TITLE
CKV_AZURE_125

### DIFF
--- a/checkov/terraform/checks/resource/azure/AzureServiceFabricClusterUseADAuth.py
+++ b/checkov/terraform/checks/resource/azure/AzureServiceFabricClusterUseADAuth.py
@@ -8,7 +8,7 @@ class AzureServiceFabricClusterUseADAuth(BaseResourceValueCheck):
         name = "Ensures that Active Directory is used for authentication for Service Fabric"
         id = "CKV_AZURE_125"
         supported_resources = ['azurerm_service_fabric_cluster']
-        categories = [CheckCategories.GENERAL_SECURITY]
+        categories = [CheckCategories.ENCRYPTION]
         super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
 
     def get_inspected_key(self):

--- a/checkov/terraform/checks/resource/azure/AzureServiceFabricClusterUseADAuth.py
+++ b/checkov/terraform/checks/resource/azure/AzureServiceFabricClusterUseADAuth.py
@@ -1,0 +1,21 @@
+from checkov.common.models.enums import CheckCategories
+from checkov.terraform.checks.resource.base_resource_value_check import BaseResourceValueCheck
+from checkov.common.models.consts import ANY_VALUE
+
+
+class AzureServiceFabricClusterUseADAuth(BaseResourceValueCheck):
+    def __init__(self):
+        name = "Ensures that Active Directory is used for authentication for Service Fabric"
+        id = "CKV_AZURE_125"
+        supported_resources = ['azurerm_service_fabric_cluster']
+        categories = [CheckCategories.GENERAL_SECURITY]
+        super().__init__(name=name, id=id, categories=categories, supported_resources=supported_resources)
+
+    def get_inspected_key(self):
+        return 'azure_active_directory/[0]/tenant_id'
+
+    def get_expected_value(self):
+        return ANY_VALUE
+
+
+check = AzureServiceFabricClusterUseADAuth()

--- a/tests/terraform/checks/resource/azure/test_AzureServiceFabricClusterUseADAuth.py
+++ b/tests/terraform/checks/resource/azure/test_AzureServiceFabricClusterUseADAuth.py
@@ -1,0 +1,69 @@
+import unittest
+
+import hcl2
+
+from checkov.terraform.checks.resource.azure.AzureServiceFabricClusterUseADAuth import check
+from checkov.common.models.enums import CheckResult
+
+
+class TestAzureServiceFabricClusterUseADAuth(unittest.TestCase):
+
+    def test_failure(self):
+        hcl_res = hcl2.loads("""
+            resource "azurerm_service_fabric_cluster" "example" {
+              name                 = "example-servicefabric"
+              resource_group_name  = azurerm_resource_group.example.name
+              location             = azurerm_resource_group.example.location
+              reliability_level    = "Bronze"
+              upgrade_mode         = "Manual"
+              cluster_code_version = "7.1.456.959"
+              vm_image             = "Windows"
+              management_endpoint  = "https://example:80"
+            
+              node_type {
+                name                 = "first"
+                instance_count       = 3
+                is_primary           = true
+                client_endpoint_port = 2020
+                http_endpoint_port   = 80
+              }
+            }
+            """)
+        resource_conf = hcl_res['resource'][0]['azurerm_service_fabric_cluster']['example']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.FAILED, scan_result)
+
+    def test_success(self):
+        hcl_res = hcl2.loads("""
+                    resource "azurerm_service_fabric_cluster" "example" {
+                      name                 = "example-servicefabric"
+                      resource_group_name  = azurerm_resource_group.example.name
+                      location             = azurerm_resource_group.example.location
+                      reliability_level    = "Bronze"
+                      upgrade_mode         = "Manual"
+                      cluster_code_version = "7.1.456.959"
+                      vm_image             = "Windows"
+                      management_endpoint  = "https://example:80"
+                      
+                      azure_active_directory {
+                        tenant_id = "4545"
+                        cluster_application_id = "87878"
+                        client_application_id = "9090"
+                      }
+
+                      node_type {
+                        name                 = "first"
+                        instance_count       = 3
+                        is_primary           = true
+                        client_endpoint_port = 2020
+                        http_endpoint_port   = 80
+                      }
+                    }
+                    """)
+        resource_conf = hcl_res['resource'][0]['azurerm_service_fabric_cluster']['example']
+        scan_result = check.scan_resource_conf(conf=resource_conf)
+        self.assertEqual(CheckResult.PASSED, scan_result)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/service_fabric_cluster#azure_active_directory
Ensures that Active Directory is used for authentication for Service Fabric