### PR TITLE
Variable evaluation bug fixes

### DIFF
--- a/checkov/graph/terraform/variable_rendering/evaluate_terraform.py
+++ b/checkov/graph/terraform/variable_rendering/evaluate_terraform.py
@@ -211,7 +211,7 @@ def evaluate_map(input_str):
                     origin_match_str = origin_match_str.replace(f'[{map_access}]', f'["{map_access}"]')
                 evaluated = _try_evaluate(origin_match_str)
                 if evaluated:
-                    input_str = input_str.replace(input_str[curly_start:square_end + 1], evaluated)
+                    input_str = input_str.replace(input_str[curly_start:square_end + 1], str(evaluated))
                     break
 
     return input_str

--- a/checkov/graph/terraform/variable_rendering/evaluate_terraform.py
+++ b/checkov/graph/terraform/variable_rendering/evaluate_terraform.py
@@ -80,7 +80,7 @@ def remove_interpolation(original_str):
         if block.full_str.startswith("${") and block.full_str.endswith("}"):
             full_str_start = original_str.find(block.full_str)
             full_str_end = full_str_start + len(block.full_str)
-            if full_str_start > 0 and full_str_end < len(original_str) - 2 and original_str[full_str_start-1] == "'" and original_str[full_str_start-1] == original_str[full_str_end] and "." in block.full_str:
+            if full_str_start > 0 and full_str_end <= len(original_str) - 2 and original_str[full_str_start-1] == "'" and original_str[full_str_start-1] == original_str[full_str_end] and "." in block.full_str:
                 # checking if ${} is wrapped with '' like : '${}'
                 original_str = original_str[:full_str_start-1] + block.full_str + original_str[full_str_end+1:]
             original_str = original_str.replace(block.full_str, block.var_only)

--- a/checkov/graph/terraform/variable_rendering/renderer.py
+++ b/checkov/graph/terraform/variable_rendering/renderer.py
@@ -2,10 +2,12 @@ import logging
 import os
 from copy import deepcopy
 
-from checkov.graph.terraform.graph_builder.graph_components.attribute_names import CustomAttributes, reserved_attribute_names
+from checkov.graph.terraform.graph_builder.graph_components.attribute_names import CustomAttributes, \
+    reserved_attribute_names
 from checkov.graph.terraform.graph_builder.graph_components.block_types import BlockType
 from checkov.graph.terraform.utils.utils import get_referenced_vertices_in_value, run_function_multithreaded, \
-    calculate_hash, join_trimmed_strings, remove_index_pattern_from_str, extend_referenced_vertices_with_tf_vars
+    calculate_hash, join_trimmed_strings, remove_index_pattern_from_str, extend_referenced_vertices_with_tf_vars, \
+    attribute_has_nested_attributes
 from checkov.graph.terraform.variable_rendering.evaluate_terraform import replace_string_value, evaluate_terraform
 
 
@@ -202,7 +204,7 @@ class VariableRenderer:
             changed_attributes = {}
             attributes = {}
             vertex.get_origin_attributes(attributes)
-            for attribute in filter(lambda attr: attr not in reserved_attribute_names, vertex.attributes):
+            for attribute in filter(lambda attr: attr not in reserved_attribute_names and not attribute_has_nested_attributes(attr, vertex.attributes), vertex.attributes):
                 curr_val = vertex.attributes.get(attribute)
                 lst_curr_val = curr_val
                 if not isinstance(lst_curr_val, list):
@@ -213,9 +215,7 @@ class VariableRenderer:
                             or attribute == 'template_body':
                         evaluated_lst.append(inner_val)
                         continue
-                    evaluated = evaluate_terraform(str(inner_val), keep_interpolations=False)
-                    if evaluated == inner_val and not isinstance(evaluated, dict):
-                        evaluated = evaluate_terraform(f'"{str(inner_val)}"', keep_interpolations=False)
+                    evaluated = self.evaluate_value(inner_val)
                     evaluated_lst.append(evaluated)
                 evaluated = evaluated_lst
                 if not isinstance(curr_val, list):
@@ -224,3 +224,23 @@ class VariableRenderer:
                     vertex.update_inner_attribute(attribute, vertex.attributes, evaluated)
                     changed_attributes[attribute] = evaluated
             self.local_graph.update_vertex_config(vertex, changed_attributes)
+
+    def evaluate_value(self, val):
+        if type(val) not in [str, list, set, dict]:
+            evaluated_val = val
+        elif isinstance(val, str):
+            evaluated_val = evaluate_terraform(val, keep_interpolations=False)
+        elif isinstance(val, list):
+            evaluated_val = []
+            for v in val:
+                evaluated_val.append(self.evaluate_value(v))
+        elif isinstance(val, set):
+            evaluated_val = set()
+            for v in val:
+                evaluated_val.add(self.evaluate_value(v))
+        else:
+            evaluated_val = {}
+            for k, v in val.items():
+                evaluated_key = self.evaluate_value(k)
+                evaluated_val[evaluated_key] = self.evaluate_value(v)
+        return evaluated_val

--- a/checkov/graph/terraform/variable_rendering/renderer.py
+++ b/checkov/graph/terraform/variable_rendering/renderer.py
@@ -101,8 +101,7 @@ class VariableRenderer:
             self.update_evaluated_value(changed_attribute_key=edge.label,
                                         changed_attribute_value=val_to_eval, vertex=edge.origin, change_origin_id=edge.dest, attribute_at_dest=first_key_path)
 
-    @staticmethod
-    def extract_value_from_vertex(key_path, attributes):
+    def extract_value_from_vertex(self, key_path, attributes):
         for i in range(len(key_path)):
             key = join_trimmed_strings(char_to_join=".", str_lst=key_path, num_to_trim=i)
             value = attributes.get(key, None)
@@ -118,7 +117,11 @@ class VariableRenderer:
                 return value
 
         if attributes.get(CustomAttributes.BLOCK_TYPE) in [BlockType.VARIABLE.value, BlockType.TF_VARIABLE.value]:
-            return attributes.get('default')
+            default_val = attributes.get('default')
+            value = None
+            if isinstance(default_val, dict):
+                value = self.extract_value_from_vertex(key_path, default_val)
+            return default_val if not value else value
         if attributes.get(CustomAttributes.BLOCK_TYPE) == BlockType.OUTPUT.value:
             return attributes.get('value')
         return None

--- a/checkov/terraform/context_parsers/parsers/locals_context_parser.py
+++ b/checkov/terraform/context_parsers/parsers/locals_context_parser.py
@@ -10,7 +10,7 @@ class LocalsContextParser(BaseContextParser):
     def _collect_local_values(self, local_block):
         if isinstance(local_block,dict):
             for local_name, local_value in local_block.items():
-                local_value = local_value[0] if isinstance(local_value, list) else local_value
+                local_value = local_value[0] if isinstance(local_value, list) and len(local_value) > 0 else local_value
                 if type(local_value) in (int, float, bool, str, dict):
                     dpath.new(self.context, ['assignments', local_name], local_value)
 

--- a/tests/graph/terraform/graph_builder/test_local_graph.py
+++ b/tests/graph/terraform/graph_builder/test_local_graph.py
@@ -22,22 +22,6 @@ class TestLocalGraph(TestCase):
     def setUp(self) -> None:
         self.source = "TERRAFORM"
 
-    def test__attribute_has_nested_attributes_dictionary(self):
-        local_graph = LocalGraph(module={}, module_dependency_map={})
-
-        attributes = {'name': ['${var.lb_name}'], 'internal': [True], 'security_groups': ['${var.lb_security_group_ids}'], 'subnets': ['${var.subnet_id}'], 'enable_deletion_protection': [True], 'tags': {'Terraform': True, 'Environment': 'sophi-staging'}, 'resource_type': ['aws_alb'], 'tags.Terraform': True, 'tags.Environment': 'sophi-staging'}
-        self.assertTrue(local_graph._attribute_has_nested_attributes(attribute_key='tags', attributes=attributes))
-        self.assertFalse(local_graph._attribute_has_nested_attributes(attribute_key='name', attributes=attributes))
-        self.assertFalse(local_graph._attribute_has_nested_attributes(attribute_key='tags.Environment', attributes=attributes))
-
-    def test__attribute_has_nested_attributes_list(self):
-        local_graph = LocalGraph(module={}, module_dependency_map={})
-
-        attributes = {'most_recent': [True], 'filter': [{'name': 'name', 'values': ['amzn-ami-hvm-*-x86_64-gp2']}, {'name': 'owner-alias', 'values': ['amazon']}], 'filter.0': {'name': 'name', 'values': ['amzn-ami-hvm-*-x86_64-gp2']}, 'filter.0.name': 'name', 'filter.0.values': ['amzn-ami-hvm-*-x86_64-gp2'], 'filter.0.values.0': 'amzn-ami-hvm-*-x86_64-gp2', 'filter.1': {'name': 'owner-alias', 'values': ['amazon']}, 'filter.1.name': 'owner-alias', 'filter.1.values': ['amazon'], 'filter.1.values.0': 'amazon'}
-        self.assertTrue(local_graph._attribute_has_nested_attributes(attribute_key='filter', attributes=attributes))
-        self.assertTrue(local_graph._attribute_has_nested_attributes(attribute_key='filter.1.values', attributes=attributes))
-        self.assertFalse(local_graph._attribute_has_nested_attributes(attribute_key='filter.1.values.0', attributes=attributes))
-
     def test_update_vertices_configs_attribute_like_resource_name(self):
         config = {"resource_type": {"resource_name": {"attribute1": 1, "attribute2": 2, "resource_name": ["caution!"]}}}
         attributes = {"attribute1": 1, "attribute2": 2, "resource_name": "ok"}

--- a/tests/graph/terraform/resources/variable_rendering/render_dictionary_tfvars/main.tf
+++ b/tests/graph/terraform/resources/variable_rendering/render_dictionary_tfvars/main.tf
@@ -1,0 +1,13 @@
+variable "aws" {
+  type = object({ access_key = string, secret_key = string, region = string })
+}
+
+variable "vcs_repo" {
+  type = object({ identifier = string, branch = string, oauth_token = string })
+}
+
+provider "aws" {
+  access_key = var.aws.access_key
+  secret_key = var.aws.secret_key
+  region     = var.aws.region
+}

--- a/tests/graph/terraform/resources/variable_rendering/render_dictionary_tfvars/terraform.tfvars
+++ b/tests/graph/terraform/resources/variable_rendering/render_dictionary_tfvars/terraform.tfvars
@@ -1,0 +1,11 @@
+aws = {
+  access_key = "AKIAVAN"
+  secret_key = "0CU4jk0"
+  region     = "us-west-2"
+}
+
+vcs_repo = {
+  branch      = "master"
+  identifier  = "DTherHtun/deploy-infra"
+  oauth_token = "885efa"
+}

--- a/tests/graph/terraform/resources/variable_rendering/terraform-aws-eks-master/eks.tf
+++ b/tests/graph/terraform/resources/variable_rendering/terraform-aws-eks-master/eks.tf
@@ -1,0 +1,19 @@
+resource "aws_eks_cluster" "tf_eks" {
+  name     = local.cluster_name
+  role_arn = aws_iam_role.master.arn
+  version  = var.kubernetes_version
+
+  vpc_config {
+    security_group_ids = [aws_security_group.master.id]
+    subnet_ids         = aws_subnet.eks[*].id
+  }
+
+  tags = {
+    project = var.project
+  }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.AmazonEKSClusterPolicy,
+    aws_iam_role_policy_attachment.AmazonEKSServicePolicy
+  ]
+}

--- a/tests/graph/terraform/resources/variable_rendering/terraform-aws-eks-master/variables.tf
+++ b/tests/graph/terraform/resources/variable_rendering/terraform-aws-eks-master/variables.tf
@@ -1,0 +1,79 @@
+variable "region" {
+  type        = string
+  description = "AWS Region"
+}
+
+variable "access_key" {
+  type        = string
+  description = "AWS Access Key"
+}
+
+variable "secret_key" {
+  type        = string
+  description = "AWS Secret Key"
+}
+
+variable "project" {
+  type = string
+}
+
+variable "cluster_name" {
+  type        = string
+  description = "EKS name"
+}
+
+variable "accessing_computer_ips" {
+  type        = list(string)
+  description = "cidr blocks"
+}
+
+variable "number_of_subnets" {
+  type        = number
+  default     = 2
+  description = "Number of subnets"
+}
+
+variable "iam_worker_instance_profile_name" {
+  type        = string
+  default     = "ipaas-eks-workers"
+  description = "IAM worker instance profile name"
+}
+
+variable "kubeconfig_path" {
+  type        = string
+  default     = "./kubeconfig"
+  description = "Kubeconfig path"
+}
+
+variable "create_kubeconfig" {
+  type        = bool
+  default     = true
+}
+
+variable "kubernetes_version" {
+  type        = string
+  default     = "1.19"
+  description = "EKS kubernetes version."
+}
+
+variable "node_groups" {
+  type = list(object({
+    name          = string
+    desired_size  = number
+    max_size      = number
+    min_size      = number
+    instance_type = string
+    # Opcionais
+    # ami_type  = string (Default: AL2_x86_64)
+    # disk_size = number (Default: 20)
+  }))
+  default = [
+    {
+      name          = "example"
+      desired_size  = 2
+      max_size      = 3
+      min_size      = 1
+      instance_type = "t3.medium"
+    }
+  ]
+}

--- a/tests/graph/terraform/variable_rendering/expected_data.py
+++ b/tests/graph/terraform/variable_rendering/expected_data.py
@@ -39,3 +39,14 @@ expected_eks = {
     }
 }
 
+
+expected_provider = {
+    "provider": {
+        "aws": {
+            "access_key": ["AKIAVAN"],
+            "secret_key": ["0CU4jk0"],
+            "region": ["us-west-2"],
+        }
+    }
+}
+

--- a/tests/graph/terraform/variable_rendering/expected_data.py
+++ b/tests/graph/terraform/variable_rendering/expected_data.py
@@ -1,3 +1,5 @@
+from lark import Tree
+
 expected_postgres_module = {"create": True,
                             "name": "${var.name}",
                             "use_name_prefix": True,
@@ -23,3 +25,17 @@ expected_terragoat_db_instance = {'name': 'db1',
                                   'tags': {'Name': 'test_id-acme-dev-rds',
                                             'Environment': 'test_id-acme-dev'}
                                   }
+
+
+expected_eks = {
+    "resource": {
+        "aws_eks_cluster.tf_eks": {
+            "version": ["1.19"],
+            "vpc_config": {
+                "security_group_ids": ["aws_security_group.master.id"],
+                "subnet_ids": Tree('full_splat_expr_term', ['aws_subnet.eks', 'id'])
+            },
+        }
+    }
+}
+

--- a/tests/graph/terraform/variable_rendering/test_renderer.py
+++ b/tests/graph/terraform/variable_rendering/test_renderer.py
@@ -132,4 +132,18 @@ class TestRenderer(TestCase):
 
         self.compare_vertex_attributes(local_graph, expected_aws_lambda_permission, BlockType.RESOURCE.value, "aws_lambda_permission.test_lambda_permissions")
 
+    def test_eks(self):
+        resources_dir = os.path.join(TEST_DIRNAME, '../resources/variable_rendering/terraform-aws-eks-master')
+        graph_manager = GraphManager('eks', ['eks'])
+        local_graph, tf_def = graph_manager.build_graph_from_source_directory(resources_dir, render_variables=True)
+
+        for v in local_graph.vertices:
+            expected_v = expected_eks.get(v.block_type, {}).get(v.name)
+            if expected_v:
+                for attribute_key, expected_value in expected_v.items():
+                    actual_value = v.attributes.get(attribute_key)
+                    self.assertEqual(expected_value, actual_value,
+                                     f'error during comparing {v.block_type} in attribute key: {attribute_key}')
+
+
 

--- a/tests/graph/terraform/variable_rendering/test_renderer.py
+++ b/tests/graph/terraform/variable_rendering/test_renderer.py
@@ -146,4 +146,18 @@ class TestRenderer(TestCase):
                                      f'error during comparing {v.block_type} in attribute key: {attribute_key}')
 
 
+    def test_dict_tfvar(self):
+        resources_dir = os.path.join(TEST_DIRNAME, '../resources/variable_rendering/render_dictionary_tfvars')
+        graph_manager = GraphManager('d', ['d'])
+        local_graph, tf_def = graph_manager.build_graph_from_source_directory(resources_dir, render_variables=True)
+
+        for v in local_graph.vertices:
+            expected_v = expected_provider.get(v.block_type, {}).get(v.name)
+            if expected_v:
+                for attribute_key, expected_value in expected_v.items():
+                    actual_value = v.attributes.get(attribute_key)
+                    self.assertEqual(expected_value, actual_value,
+                                     f'error during comparing {v.block_type} in attribute key: {attribute_key}')
+
+
 


### PR DESCRIPTION
1. Moved the local_graph method `_attribute_has_nested_attributes` to utils package
2. Fixed a bug when trying to replace a value in a string with a non-string value (in `evaluate_terraform`)
3. When evaluating non-rendered value, evaluate only inner-most values and do it recursively on lists/sets/dictionaries to avoid evaluating non-string values into strings.
4. Fixed `list index out of range` by checking the length in locals_context_parser
5. Fixed `expected string or bytes-like object` by correctly rendering values from variables with maps as default values

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
