### PR TITLE
Solve policies with resources that have multiple connections

### DIFF
--- a/checkov/terraform/checks_infra/solvers/connections_solvers/base_connection_solver.py
+++ b/checkov/terraform/checks_infra/solvers/connections_solvers/base_connection_solver.py
@@ -14,6 +14,7 @@ class BaseConnectionSolver(BaseSolver):
         self.connected_resources_types = connected_resources_types
         self.vertices_under_resource_types = vertices_under_resource_types or []
         self.vertices_under_connected_resources_types = vertices_under_connected_resources_types or []
+        self.excluded_vertices = []
 
     def run(self, graph_connector: DiGraph):
         self.set_vertices(graph_connector, [])
@@ -28,9 +29,10 @@ class BaseConnectionSolver(BaseSolver):
 
     def set_vertices(self, graph_connector, exclude_vertices):
         self.vertices_under_resource_types = [v for _, v in graph_connector.nodes(data=True) if
-                                              self.resource_type_pred(v, self.resource_types) and v not in exclude_vertices]
+                                              self.resource_type_pred(v, self.resource_types)]
         self.vertices_under_connected_resources_types = [v for _, v in graph_connector.nodes(data=True) if
-                                                         self.resource_type_pred(v, self.connected_resources_types) and v not in exclude_vertices]
+                                                         self.resource_type_pred(v, self.connected_resources_types)]
+        self.excluded_vertices = [v for v in self.vertices_under_resource_types + self.vertices_under_connected_resources_types if v not in exclude_vertices]
 
     def get_operation(self, graph_connector):
         raise NotImplementedError

--- a/checkov/terraform/checks_infra/solvers/connections_solvers/base_connection_solver.py
+++ b/checkov/terraform/checks_infra/solvers/connections_solvers/base_connection_solver.py
@@ -32,7 +32,7 @@ class BaseConnectionSolver(BaseSolver):
                                               self.resource_type_pred(v, self.resource_types)]
         self.vertices_under_connected_resources_types = [v for _, v in graph_connector.nodes(data=True) if
                                                          self.resource_type_pred(v, self.connected_resources_types)]
-        self.excluded_vertices = [v for v in self.vertices_under_resource_types + self.vertices_under_connected_resources_types if v not in exclude_vertices]
+        self.excluded_vertices = [v for v in self.vertices_under_resource_types + self.vertices_under_connected_resources_types if v in exclude_vertices]
 
     def get_operation(self, graph_connector):
         raise NotImplementedError

--- a/checkov/terraform/checks_infra/solvers/connections_solvers/connection_exists_solver.py
+++ b/checkov/terraform/checks_infra/solvers/connections_solvers/connection_exists_solver.py
@@ -13,6 +13,7 @@ class ConnectionExistsSolver(BaseConnectionSolver):
 
     def get_operation(self, graph_connector):
         passed = []
+        failed = []
         for u, v in edge_dfs(graph_connector):
             origin_attributes = graph_connector.nodes(data=True)[u]
             opposite_vertices = None
@@ -25,7 +26,10 @@ class ConnectionExistsSolver(BaseConnectionSolver):
 
             destination_attributes = graph_connector.nodes(data=True)[v]
             if destination_attributes in opposite_vertices:
-                passed.extend([origin_attributes, destination_attributes])
+                if origin_attributes in self.excluded_vertices or destination_attributes in self.excluded_vertices:
+                    failed.extend([origin_attributes, destination_attributes])
+                else:
+                    passed.extend([origin_attributes, destination_attributes])
                 continue
 
             destination_block_type = destination_attributes.get(CustomAttributes.BLOCK_TYPE)
@@ -39,5 +43,5 @@ class ConnectionExistsSolver(BaseConnectionSolver):
                         passed.extend([origin_attributes, output_destination])
                 except StopIteration:
                     continue
-        failed = [v for v in self.vertices_under_resource_types + self.vertices_under_connected_resources_types if v not in passed]
+        failed.extend([v for v in self.vertices_under_resource_types + self.vertices_under_connected_resources_types if v not in passed])
         return passed, failed

--- a/tests/graph/terraform/checks_infra/connection_solvers/and_connection_solver/ALBConnectedToHTTPS.yaml
+++ b/tests/graph/terraform/checks_infra/connection_solvers/and_connection_solver/ALBConnectedToHTTPS.yaml
@@ -1,0 +1,23 @@
+metadata:
+  id: "ALBConnectedToHTTPS"
+  name: "Ensure that ALB redirects HTTP requests into HTTPS ones"
+  category: "NETWORKING"
+definition:
+  and:
+    - cond_type: "filter"
+      value:
+        - "aws_lb"
+      attribute: "resource_type"
+      operator: "within"
+    - cond_type: "connection"
+      resource_types:
+        - "aws_lb"
+      connected_resource_types:
+        - "aws_lb_listener"
+      operator: "exists"
+    - cond_type: "attribute"
+      resource_types:
+        - "aws_lb_listener"
+      attribute: "protocol"
+      operator: "equals"
+      value: "HTTPS"

--- a/tests/graph/terraform/checks_infra/connection_solvers/and_connection_solver/ALBConnectedToHTTPS.yaml
+++ b/tests/graph/terraform/checks_infra/connection_solvers/and_connection_solver/ALBConnectedToHTTPS.yaml
@@ -4,20 +4,44 @@ metadata:
   category: "NETWORKING"
 definition:
   and:
-    - cond_type: "filter"
-      value:
-        - "aws_lb"
-      attribute: "resource_type"
-      operator: "within"
+  - cond_type: "filter"
+    value:
+      - "aws_lb"
+    attribute: "resource_type"
+    operator: "within"
+  - cond_type: "attribute"
+    resource_types:
+      - "aws_lb"
+    attribute: "load_balancer_type"
+    operator: "equals"
+    value: "application"
+  - or:
     - cond_type: "connection"
       resource_types:
         - "aws_lb"
       connected_resource_types:
         - "aws_lb_listener"
-      operator: "exists"
-    - cond_type: "attribute"
-      resource_types:
-        - "aws_lb_listener"
-      attribute: "protocol"
-      operator: "equals"
-      value: "HTTPS"
+      operator: "not_exists"
+    - and:
+      - cond_type: "connection"
+        resource_types:
+          - "aws_lb"
+        connected_resource_types:
+          - "aws_lb_listener"
+        operator: "exists"
+      - cond_type: "attribute"
+        resource_types:
+          - "aws_lb_listener"
+        attribute: "certificate_arn"
+        operator: "exists"
+      - cond_type: "attribute"
+        resource_types:
+          - "aws_lb_listener"
+        attribute: "ssl_policy"
+        operator: "exists"
+      - cond_type: "attribute"
+        resource_types:
+          - "aws_lb_listener"
+        attribute: "protocol"
+        operator: "equals"
+        value: "HTTPS"

--- a/tests/graph/terraform/checks_infra/connection_solvers/and_connection_solver/test_solver.py
+++ b/tests/graph/terraform/checks_infra/connection_solvers/and_connection_solver/test_solver.py
@@ -17,3 +17,12 @@ class ConnectionSolver(TestBaseSolver):
         expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
 
         self.run_test(root_folder=root_folder, expected_results=expected_results, check_id=check_id)
+
+    def test_multiple_connections(self):
+        root_folder = '../../../resources/lb'
+        check_id = "ALBConnectedToHTTPS"
+        should_pass = []
+        should_fail = ["aws_lb.lb_bad_1"]
+        expected_results = {check_id: {"should_pass": should_pass, "should_fail": should_fail}}
+
+        self.run_test(root_folder=root_folder, expected_results=expected_results, check_id=check_id)

--- a/tests/graph/terraform/resources/lb/main.tf
+++ b/tests/graph/terraform/resources/lb/main.tf
@@ -1,0 +1,41 @@
+resource "aws_lb" "lb_bad_1" {
+  name               = "test-lb-tf-https-listener"
+  internal           = false
+  load_balancer_type = "application"
+
+  enable_deletion_protection = true
+  tags = {
+    Environment = "production"
+  }
+}
+
+resource "aws_lb_listener" "listener_http_1" {
+  load_balancer_arn = aws_lb.lb_bad_1.arn
+  port              = "80"
+  protocol          = "HTTP"
+  ssl_policy        = "ELBSecurityPolicy-2016-08"
+  certificate_arn   = "arn:aws:iam::187416307283:server-certificate/test_cert_rab3wuqwgja25ct3n4jdj2tzu4"
+
+  default_action {
+    type = "redirect"
+  }
+}
+
+
+resource "aws_lb_listener" "listener_https_1" {
+  load_balancer_arn = aws_lb.lb_bad_1.arn
+  port              = "443"
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-2016-08"
+  certificate_arn   = "arn:aws:iam::187416307283:server-certificate/test_cert_rab3wuqwgja25ct3n4jdj2tzu4"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}


### PR DESCRIPTION
This PR solves the following issue:
Assume we have a policy that checks if:
- connection exists between resource `A` to resource `B`
- `B` has attribute `x`
- Return all `A` that comply to this policy

In the input file we have resources `A1`, `B1` and `B2`
we have edges `A1->B1` and `A1->B2`
`B1` has attribute `x` but `B2` doesn't.
According to the policy definitions, `A1` should fail, before this fix `A1` would pass due to the connection to `B1`.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
